### PR TITLE
chore: READMEに開発環境とブランチメモを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,14 @@
-# README
+# Mahjong Score
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+麻雀の半荘結果を記録・集計できる麻雀スコア管理アプリ（Web）
 
-Things you may want to cover:
+## 開発環境（Docker）
 
-* Ruby version
+起動：
+- docker compose up
 
-* System dependencies
+アクセス：
+- http://localhost:3000
 
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+## ブランチメモ
+- chore/initial-setup: Rails + Docker + PostgreSQL の初期構成保存用（以後更新しない）


### PR DESCRIPTION
## 変更内容
- README に開発環境（Docker 起動方法）を追記
- ブランチ用途のメモを追加

## 目的
- 初見でも起動方法が分かるようにするため
- 初期構成ブランチの意図を残すため

## 影響範囲
- README のみ（アプリの挙動変更なし）