### PR TITLE
feat: games#create（対局＋プレイヤーを保存する）を実装

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -3,6 +3,12 @@ class GamesController < ApplicationController
   end
 
   def create
-    redirect_to root_path
+    ActiveRecord::Base.transaction do
+      game = Game.create!(rule_type: "default")
+      params[:players].each { |name| game.players.create!(name: name) }
+      redirect_to new_game_round_path(game)
+    end
+  rescue ActiveRecord::RecordInvalid
+    redirect_to new_game_path
   end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,0 +1,3 @@
+class Game < ApplicationRecord
+  has_many :players
+end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -1,0 +1,4 @@
+class Player < ApplicationRecord
+  belongs_to :game
+  validates :name, presence: true
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,7 +33,7 @@ module App
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Tokyo"
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Don't generate system test files.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,5 +8,7 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root "home#index"
 
-  resources :games, only: [:new, :create]
+  resources :games, only: [:new, :create, :show] do
+    resources :rounds, only: [:new, :create]
+  end
 end

--- a/db/migrate/20260207045241_create_games.rb
+++ b/db/migrate/20260207045241_create_games.rb
@@ -1,0 +1,9 @@
+class CreateGames < ActiveRecord::Migration[7.1]
+  def change
+    create_table :games do |t|
+      t.string :rule_type
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260207045314_create_players.rb
+++ b/db/migrate/20260207045314_create_players.rb
@@ -1,0 +1,10 @@
+class CreatePlayers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :players do |t|
+      t.string :name
+      t.references :game, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,32 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.1].define(version: 2026_02_07_045314) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "games", force: :cascade do |t|
+    t.string "rule_type"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "players", force: :cascade do |t|
+    t.string "name"
+    t.bigint "game_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["game_id"], name: "index_players_on_game_id"
+  end
+
+  add_foreign_key "players", "games"
+end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Game, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Player, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,6 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
-ENV['RAILS_ENV'] ||= 'test'
+ENV['RAILS_ENV'] = 'test'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -2,9 +2,39 @@ require 'rails_helper'
 
 RSpec.describe "Games", type: :request do
   describe "POST /games" do
-    it "redirects to root path" do
-      post games_path, params: { players: ["Player1", "Player2", "Player3", "Player4"] }
-      expect(response).to redirect_to(root_path)
+    context "4人分のプレイヤー名が入力された場合" do
+      let(:players) { ["Player1", "Player2", "Player3", "Player4"] }
+
+      it "Game が1件作成される" do
+        expect {
+          post games_path, params: { players: players }
+        }.to change(Game, :count).by(1)
+      end
+
+      it "Player が4件作成され、Game に紐づいている" do
+        expect {
+          post games_path, params: { players: players }
+        }.to change(Player, :count).by(4)
+
+        game = Game.last
+        expect(game.players.map(&:name)).to eq(players)
+      end
+
+      it "点数入力画面にリダイレクトする" do
+        post games_path, params: { players: players }
+        game = Game.last
+        expect(response).to redirect_to(new_game_round_path(game))
+      end
+    end
+
+    context "プレイヤー名に空欄がある場合" do
+      let(:players) { ["Player1", "", "Player3", "Player4"] }
+
+      it "Game と Player が作成されない" do
+        expect {
+          post games_path, params: { players: players }
+        }.to change(Game, :count).by(0).and change(Player, :count).by(0)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- Game, Player モデルとマイグレーションを追加し、games#create で対局とプレイヤー4人分をDBに保存する処理を実装
- 保存後に点数入力画面（/games/:id/rounds/new）へリダイレクト
- タイムゾーンを Tokyo に設定、rails_helper で RAILS_ENV=test を強制するよう修正

## Test plan
- [x] POST /games で Game が1件作成される
- [x] POST /games で Player が4件作成され、Game に紐づいている
- [x] 保存後に /games/:id/rounds/new へリダイレクトする
- [x] プレイヤー名に空欄がある場合、Game と Player が作成されない

closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)