### PR TITLE
chore: CLAUDE.mdをプロジェクトルートに追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,53 @@
+# CLAUDE.md
+
+## プロジェクト概要
+- シンプルで使いやすい麻雀スコア管理アプリを開発する
+- MVPを最短でリリースし、段階的に改善する
+- MPA → SPA → LIFF → ネイティブ(iOS・Android) の順で拡張する
+
+## 技術スタック
+- Ruby 3.3.10 / Rails 7.1.3
+- PostgreSQL 16
+- Hotwire (Turbo + Stimulus)
+- Docker / Docker Compose
+- テスト: RSpec + FactoryBot
+
+## コマンド
+- テスト実行: `docker compose run --rm -e RAILS_ENV=test web bash -lc "bundle install && bundle exec rspec"`
+- マイグレーション: `docker compose exec web bin/rails db:migrate`
+- コンソール: `docker compose exec web bin/rails console`
+- サーバー起動: `docker compose up`
+- ルーティング確認: `docker compose exec web bin/rails routes`
+
+## 開発プロセス
+- TDDで開発する
+- 必ずテストを先に書き、失敗を確認してから実装する
+- Red → Green → Refactor のサイクルを守る
+
+## AIへの制約事項
+- 結論を先に書く
+- 新機能や修正を提案する際は、まず「どのようなテストケースが必要か」を提示する
+- ユーザーの承諾を得る前に、テストのない実装コードを大量に生成しない
+- リファクタリングフェーズを省略しない
+- 実装はシンプルを最優先にする
+- MVPに不要な機能は「今回はやらない」と明言する
+
+## 期待する振る舞い
+- TDD（テスト駆動開発）の専門家として振る舞う
+- 変更時は【現状】→【目的】→【変更内容】の順で説明する
+- QA視点でのリスクや懸念点があれば遠慮なく指摘する
+- 「？」と聞かれたらわかりやすく意図を説明する
+
+## コーディング規約
+- 1関数1責務
+- エラーは明示的にハンドリングする
+- コミットメッセージは日本語でわかりやすく残す
+- テストデータの作成にはFactoryBotを使う
+
+## Git運用
+- mainブランチで直接開発しない
+- ブランチはissue単位で切る
+
+## 将来的に実装したい機能
+- ブラウザ版、LIFF版、ネイティブ版（iOS・Android）問わずどこからでも過去の履歴（成績）が見られる機能を実装する
+- 同卓した人なら誰からでも過去の履歴（成績）が見られる機能を実装する


### PR DESCRIPTION
## Summary
- プロジェクトルートにCLAUDE.mdを追加
- プロジェクト概要、技術スタック、コマンド、開発プロセス、コーディング規約などをまとめたAI向け設定ファイル

## Test plan
- [x] CLAUDE.mdの内容が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)