### PR TITLE
fix: ゲーム開始後のリダイレクト先をスコア一覧画面に変更

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -6,7 +6,7 @@ class GamesController < ApplicationController
     ActiveRecord::Base.transaction do
       game = Game.create!(rule_type: "default")
       params[:players].each { |name| game.players.create!(name: name) }
-      redirect_to new_game_round_path(game)
+      redirect_to game_path(game)
     end
   rescue ActiveRecord::RecordInvalid
     redirect_to new_game_path

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -20,10 +20,10 @@ RSpec.describe "Games", type: :request do
         expect(game.players.map(&:name)).to eq(players)
       end
 
-      it "点数入力画面にリダイレクトする" do
+      it "スコア一覧画面にリダイレクトする" do
         post games_path, params: { players: players }
         game = Game.last
-        expect(response).to redirect_to(new_game_round_path(game))
+        expect(response).to redirect_to(game_path(game))
       end
     end
 


### PR DESCRIPTION
## Summary
- `games#create` のリダイレクト先を `rounds#new`（点数入力画面）から `games#show`（スコア一覧画面）に変更
- 対応するテストのリダイレクト先とテスト名を修正

## Test plan
- [x] `bundle exec rspec` 全テスト通過（6 examples, 0 failures）
- [x] ブラウザで「ゲーム開始」押下後、`/games/:id` に遷移することを確認

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)