### PR TITLE
chore: FactoryBot を導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]
   gem "rspec-rails"
+  gem "factory_bot_rails"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,11 @@ GEM
     drb (2.2.3)
     erb (6.0.1)
     erubi (1.13.1)
+    factory_bot (6.5.6)
+      activesupport (>= 6.1.0)
+    factory_bot_rails (6.5.1)
+      factory_bot (~> 6.5)
+      railties (>= 6.1.0)
     globalid (1.3.0)
       activesupport (>= 6.1)
     i18n (1.14.8)
@@ -282,6 +287,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   debug
+  factory_bot_rails
   importmap-rails
   jbuilder
   pg (~> 1.1)

--- a/spec/factories/games.rb
+++ b/spec/factories/games.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :game do
+    rule_type { "default" }
+  end
+end

--- a/spec/factories/players.rb
+++ b/spec/factories/players.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :player do
+    sequence(:name) { |n| "プレイヤー#{n}" }
+    game
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,6 +33,8 @@ rescue ActiveRecord::PendingMigrationError => e
   abort e.to_s.strip
 end
 RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [
     Rails.root.join('spec/fixtures')


### PR DESCRIPTION
## Summary
- `factory_bot_rails` gem を追加
- `spec/rails_helper.rb` に `FactoryBot::Syntax::Methods` を include
- Game, Player の Factory ファイルを作成

## Test plan
- [x] `bundle exec rspec` 全テスト通過（6 examples, 0 failures）

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)