### PR TITLE
feat: スコア一覧画面（games#show）を実装

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -134,3 +134,53 @@
 .back-link a:hover {
   text-decoration: underline;
 }
+
+/* Games show page styles */
+.games-show {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-height: 100vh;
+  padding: 40px 20px;
+}
+
+.games-show h1 {
+  font-size: 2rem;
+  margin-bottom: 2rem;
+  color: #333;
+}
+
+.score-table {
+  width: 100%;
+  max-width: 600px;
+  border-collapse: collapse;
+  margin-bottom: 2rem;
+}
+
+.score-table th,
+.score-table td {
+  border: 1px solid #ccc;
+  padding: 10px 12px;
+  text-align: center;
+}
+
+.score-table thead th {
+  background-color: #e9ecef;
+  font-weight: bold;
+  color: #333;
+}
+
+.score-table tbody td:first-child {
+  background-color: #f8f9fa;
+  font-weight: bold;
+  color: #666;
+}
+
+.score-table tfoot td {
+  background-color: #e9ecef;
+  font-weight: bold;
+}
+
+.actions {
+  margin-bottom: 1rem;
+}

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,4 +1,10 @@
 class GamesController < ApplicationController
+  def show
+    @game = Game.find(params[:id])
+    @players = @game.players.order(:created_at)
+    @rounds = @game.rounds.includes(:scores).order(:round_number)
+  end
+
   def new
   end
 

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,3 +1,4 @@
 class Game < ApplicationRecord
   has_many :players
+  has_many :rounds
 end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -1,4 +1,5 @@
 class Player < ApplicationRecord
   belongs_to :game
+  has_many :scores
   validates :name, presence: true
 end

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -1,0 +1,7 @@
+class Round < ApplicationRecord
+  belongs_to :game
+  has_many :scores
+
+  validates :round_number, presence: true,
+            uniqueness: { scope: :game_id }
+end

--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -1,0 +1,7 @@
+class Score < ApplicationRecord
+  belongs_to :round
+  belongs_to :player
+
+  validates :point, presence: true
+  validates :player_id, uniqueness: { scope: :round_id }
+end

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,0 +1,37 @@
+<div class="games-show">
+  <h1>スコア一覧</h1>
+
+  <table class="score-table">
+    <thead>
+      <tr>
+        <th></th>
+        <% @players.each do |player| %>
+          <th><%= player.name %></th>
+        <% end %>
+      </tr>
+    </thead>
+    <tbody>
+      <% (1..10).each do |num| %>
+        <% round = @rounds.find { |r| r.round_number == num } %>
+        <tr>
+          <td><%= link_to num, new_game_round_path(@game, round_number: num) %></td>
+          <% @players.each do |player| %>
+            <td><%= round&.scores&.find { |s| s.player_id == player.id }&.point %></td>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+    <tfoot>
+      <tr>
+        <td>合計</td>
+        <% @players.each do |player| %>
+          <td><%= @rounds.sum { |r| r.scores.find { |s| s.player_id == player.id }&.point.to_i } %></td>
+        <% end %>
+      </tr>
+    </tfoot>
+  </table>
+
+  <div class="back-link">
+    <%= link_to "← トップに戻る", root_path %>
+  </div>
+</div>

--- a/db/migrate/20260208052804_create_rounds.rb
+++ b/db/migrate/20260208052804_create_rounds.rb
@@ -1,0 +1,12 @@
+class CreateRounds < ActiveRecord::Migration[7.1]
+  def change
+    create_table :rounds do |t|
+      t.references :game, null: false, foreign_key: true
+      t.integer :round_number, null: false
+
+      t.timestamps
+    end
+
+    add_index :rounds, [:game_id, :round_number], unique: true
+  end
+end

--- a/db/migrate/20260208052810_create_scores.rb
+++ b/db/migrate/20260208052810_create_scores.rb
@@ -1,0 +1,13 @@
+class CreateScores < ActiveRecord::Migration[7.1]
+  def change
+    create_table :scores do |t|
+      t.references :round, null: false, foreign_key: true
+      t.references :player, null: false, foreign_key: true
+      t.integer :point, null: false
+
+      t.timestamps
+    end
+
+    add_index :scores, [:round_id, :player_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_02_07_045314) do
+ActiveRecord::Schema[7.1].define(version: 2026_02_08_052810) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -28,5 +28,28 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_07_045314) do
     t.index ["game_id"], name: "index_players_on_game_id"
   end
 
+  create_table "rounds", force: :cascade do |t|
+    t.bigint "game_id", null: false
+    t.integer "round_number", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["game_id", "round_number"], name: "index_rounds_on_game_id_and_round_number", unique: true
+    t.index ["game_id"], name: "index_rounds_on_game_id"
+  end
+
+  create_table "scores", force: :cascade do |t|
+    t.bigint "round_id", null: false
+    t.bigint "player_id", null: false
+    t.integer "point", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["player_id"], name: "index_scores_on_player_id"
+    t.index ["round_id", "player_id"], name: "index_scores_on_round_id_and_player_id", unique: true
+    t.index ["round_id"], name: "index_scores_on_round_id"
+  end
+
   add_foreign_key "players", "games"
+  add_foreign_key "rounds", "games"
+  add_foreign_key "scores", "players"
+  add_foreign_key "scores", "rounds"
 end

--- a/spec/factories/rounds.rb
+++ b/spec/factories/rounds.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :round do
+    game
+    sequence(:round_number) { |n| n }
+  end
+end

--- a/spec/factories/scores.rb
+++ b/spec/factories/scores.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :score do
+    round
+    player
+    point { 25000 }
+  end
+end

--- a/spec/models/round_spec.rb
+++ b/spec/models/round_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Round, type: :model do
+  describe "バリデーション" do
+    it "game と round_number が揃っていれば有効" do
+      round = build(:round)
+      expect(round).to be_valid
+    end
+
+    it "game がなければ無効" do
+      round = build(:round, game: nil)
+      expect(round).to be_invalid
+    end
+
+    it "round_number がなければ無効" do
+      round = build(:round, round_number: nil)
+      expect(round).to be_invalid
+    end
+
+    it "同一 game 内で round_number が重複すれば無効" do
+      game = create(:game)
+      create(:round, game: game, round_number: 1)
+      duplicate = build(:round, game: game, round_number: 1)
+      expect(duplicate).to be_invalid
+    end
+
+    it "異なる game なら同じ round_number が許可される" do
+      create(:round, round_number: 1)
+      round = build(:round, round_number: 1)
+      expect(round).to be_valid
+    end
+  end
+end

--- a/spec/models/score_spec.rb
+++ b/spec/models/score_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe Score, type: :model do
+  describe "バリデーション" do
+    let(:game) { create(:game) }
+    let(:round) { create(:round, game: game) }
+    let(:player) { create(:player, game: game) }
+
+    it "round, player, point が揃っていれば有効" do
+      score = build(:score, round: round, player: player)
+      expect(score).to be_valid
+    end
+
+    it "round がなければ無効" do
+      score = build(:score, round: nil, player: player)
+      expect(score).to be_invalid
+    end
+
+    it "player がなければ無効" do
+      score = build(:score, round: round, player: nil)
+      expect(score).to be_invalid
+    end
+
+    it "point がなければ無効" do
+      score = build(:score, round: round, player: player, point: nil)
+      expect(score).to be_invalid
+    end
+
+    it "同一 round 内で player が重複すれば無効" do
+      create(:score, round: round, player: player)
+      duplicate = build(:score, round: round, player: player)
+      expect(duplicate).to be_invalid
+    end
+  end
+end

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -37,4 +37,68 @@ RSpec.describe "Games", type: :request do
       end
     end
   end
+
+  describe "GET /games/:id" do
+    let(:game) { create(:game) }
+    let!(:players) do
+      %w[Alice Bob Carol Dave].map { |name| create(:player, game: game, name: name) }
+    end
+
+    context "半荘データがない場合" do
+      it "ステータス200が返る" do
+        get game_path(game)
+        expect(response).to have_http_status(200)
+      end
+
+      it "プレイヤー名が全員表示される" do
+        get game_path(game)
+        %w[Alice Bob Carol Dave].each do |name|
+          expect(response.body).to include(name)
+        end
+      end
+
+      it "行番号が点数入力画面へのリンクになっている" do
+        get game_path(game)
+        (1..10).each do |num|
+          expect(response.body).to include(new_game_round_path(game, round_number: num))
+        end
+      end
+
+      it "合計行が表示される" do
+        get game_path(game)
+        expect(response.body).to include("合計")
+      end
+    end
+
+    context "半荘データがある場合" do
+      let!(:round1) { create(:round, game: game, round_number: 1) }
+      let!(:round2) { create(:round, game: game, round_number: 2) }
+
+      before do
+        [30000, 25000, 25000, 20000].each_with_index do |point, i|
+          create(:score, round: round1, player: players[i], point: point)
+        end
+        [40000, 20000, 25000, 15000].each_with_index do |point, i|
+          create(:score, round: round2, player: players[i], point: point)
+        end
+      end
+
+      it "各プレイヤーの点数が表示される" do
+        get game_path(game)
+        expect(response.body).to include("30000")
+        expect(response.body).to include("40000")
+      end
+
+      it "半荘が round_number 昇順で表示される" do
+        get game_path(game)
+        expect(response.body.index("30000")).to be < response.body.index("40000")
+      end
+
+      it "合計行が表示される" do
+        get game_path(game)
+        expect(response.body).to include("70000")  # Alice: 30000 + 40000
+        expect(response.body).to include("45000")  # Bob: 25000 + 20000
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Round, Score モデルとマイグレーションを追加し、スコア一覧画面を実装
- 10行固定のスコアテーブル、合計行、行番号から点数入力画面へのリンクを表示
- request spec で半荘データあり・なし両ケースを検証

## Test plan
- [x] 半荘データがない場合に200が返り、プレイヤー名・合計行・行番号リンクが表示される
- [x] 半荘データがある場合に点数・昇順表示・合計値が正しく表示される
- [x] 全23件パス、0 failures

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)