### PR TITLE
rounds#create を実装

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -305,6 +305,23 @@
   letter-spacing: 0.02em;
 }
 
+.form-error {
+  margin: 8px 0 16px;
+  padding: 10px 12px;
+  border: 1px solid #d27d7d;
+  border-radius: 8px;
+  background: #ffe9e9;
+  color: #7a1f1f;
+  font-weight: 700;
+}
+
+.validation-message {
+  margin: 10px 0 0;
+  color: #7a1f1f;
+  font-weight: 700;
+  text-align: center;
+}
+
 .scoreboard tfoot th,
 .scoreboard tfoot td {
   background: #d9e6fb;
@@ -329,6 +346,12 @@
   border-radius: 8px;
   font-weight: 700;
   letter-spacing: 0.03em;
+}
+
+.rounds-submit:disabled,
+.rounds-submit.is-disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .rounds-submit:hover {

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -2,11 +2,52 @@ class RoundsController < ApplicationController
   def new
     @game = Game.find(params[:game_id])
     @players = @game.players.order(:created_at)
-    @round_number = params[:round_number]
+    @round_number = params[:round_number].presence&.to_i || @game.rounds.maximum(:round_number).to_i + 1
+    @score_values = {}
   end
 
   def create
-    game = Game.find(params[:game_id])
-    redirect_to game_path(game)
+    @game = Game.find(params[:game_id])
+    @players = @game.players.order(:created_at)
+    @score_values = params.fetch(:scores, {})
+    requested_round_number = params[:round_number].presence&.to_i
+    @round_number = requested_round_number || @game.rounds.maximum(:round_number).to_i + 1
+    min_unit = -1000
+    max_unit = 1000
+
+    score_units = @players.map do |player|
+      raw = @score_values[player.id.to_s]
+      next if raw.blank?
+      next unless raw.match?(/\A-?\d+\z/)
+
+      raw.to_i
+    end
+
+    if score_units.any?(&:nil?)
+      @error_message = "入力内容を確認してください"
+      return render :new, status: 422
+    end
+
+    if score_units.any? { |unit| unit < min_unit || unit > max_unit }
+      @error_message = "入力内容を確認してください"
+      return render :new, status: 422
+    end
+
+    if score_units.sum != 1000
+      @error_message = "入力内容を確認してください"
+      return render :new, status: 422
+    end
+
+    round = @game.rounds.find_or_initialize_by(round_number: @round_number)
+
+    ActiveRecord::Base.transaction do
+      round.save! if round.new_record?
+      @players.each_with_index do |player, index|
+        score = round.scores.find_or_initialize_by(player: player)
+        score.update!(point: score_units[index] * 100)
+      end
+    end
+
+    redirect_to game_path(@game)
   end
 end

--- a/app/views/rounds/new.html.erb
+++ b/app/views/rounds/new.html.erb
@@ -2,6 +2,10 @@
   <div class="rounds-panel">
     <h1>点数入力</h1>
 
+    <% if @error_message.present? %>
+      <div class="form-error" role="alert"><%= @error_message %></div>
+    <% end %>
+
     <%= form_with url: game_rounds_path(@game), method: :post, local: true, class: "rounds-form" do %>
       <% if @round_number.present? %>
         <%= hidden_field_tag :round_number, @round_number %>
@@ -25,12 +29,12 @@
                 <label for="score_<%= player.id %>" class="sr-only"><%= player.name %>の点数</label>
                 <div class="score-field">
                   <%= text_field_tag "scores[#{player.id}]",
-                                     nil,
+                                     @score_values&.dig(player.id.to_s),
                                      id: "score_#{player.id}",
                                      inputmode: "numeric",
-                                     pattern: "[0-9]*",
+                                     pattern: "-?[0-9]*",
                                      autocomplete: "off",
-                                     maxlength: 4,
+                                     maxlength: 5,
                                      class: "score-input" %>
                   <span class="score-unit score-unit--hundreds">00点</span>
                 </div>
@@ -51,6 +55,7 @@
 
       <div class="form-actions">
         <%= submit_tag "入力完了", class: "btn btn-primary rounds-submit" %>
+        <p class="validation-message" data-validation-message hidden>入力内容を確認してください</p>
       </div>
     <% end %>
   </div>
@@ -67,11 +72,16 @@
 
     const inputs = Array.from(form.querySelectorAll(".score-input"));
     const totalOutput = form.querySelector("[data-total-output]");
+    const submitButton = form.querySelector(".rounds-submit");
+    const validationMessage = form.querySelector("[data-validation-message]");
+    let hasInteracted = false;
     if (inputs.length === 0 || !totalOutput) return;
 
     const TARGET_TOTAL = 100000;
     const UNIT_SCALE = 100;
     const TARGET_UNITS = TARGET_TOTAL / UNIT_SCALE;
+    const MIN_UNIT = -1000;
+    const MAX_UNIT = 1000;
 
     const parseValue = (value) => {
       if (value == null) return null;
@@ -115,11 +125,27 @@
         delete autoInput.dataset.auto;
       }
 
-      totalOutput.textContent = String(sumUnits() * UNIT_SCALE);
+      const totalUnits = sumUnits();
+      totalOutput.textContent = String(totalUnits * UNIT_SCALE);
+
+      if (submitButton) {
+        const allFilled = inputs.every((input) => parseValue(input.value) != null);
+        const inRange = inputs.every((input) => {
+          const value = parseValue(input.value);
+          return value == null || (value >= MIN_UNIT && value <= MAX_UNIT);
+        });
+        const isValid = allFilled && totalUnits === TARGET_UNITS && inRange;
+        submitButton.disabled = !isValid;
+        submitButton.classList.toggle("is-disabled", !isValid);
+        if (validationMessage) {
+          validationMessage.hidden = isValid || !hasInteracted;
+        }
+      }
     };
 
     inputs.forEach((input) => {
       input.addEventListener("input", () => {
+        hasInteracted = true;
         input.dataset.manual = "true";
         if (input.dataset.auto === "true") delete input.dataset.auto;
         update();

--- a/spec/requests/rounds_spec.rb
+++ b/spec/requests/rounds_spec.rb
@@ -44,9 +44,98 @@ RSpec.describe "Rounds", type: :request do
 
   describe "POST /games/:game_id/rounds" do
     let(:game) { create(:game) }
+    let!(:players) do
+      %w[Alice Bob Carol Dave].map { |name| create(:player, game: game, name: name) }
+    end
+    let(:scores_params) do
+      {
+        players[0].id.to_s => "250",
+        players[1].id.to_s => "300",
+        players[2].id.to_s => "200",
+        players[3].id.to_s => "250"
+      }
+    end
+
+    it "Round が1件作成される" do
+      expect {
+        post game_rounds_path(game), params: { round_number: 1, scores: scores_params }
+      }.to change(Round, :count).by(1)
+    end
+
+    it "Score が4件作成される" do
+      expect {
+        post game_rounds_path(game), params: { round_number: 1, scores: scores_params }
+      }.to change(Score, :count).by(4)
+    end
+
+    it "round_number が1で保存される" do
+      post game_rounds_path(game), params: { round_number: 1, scores: scores_params }
+      expect(Round.last.round_number).to eq(1)
+    end
+
+    it "入力値を100倍して保存する" do
+      post game_rounds_path(game), params: { round_number: 1, scores: scores_params }
+      round = Round.last
+      players.each do |player|
+        expect(round.scores.find_by(player: player).point).to eq(scores_params[player.id.to_s].to_i * 100)
+      end
+    end
+
+    it "既存最大値 + 1 の round_number になる" do
+      create(:round, game: game, round_number: 3)
+      post game_rounds_path(game), params: { scores: scores_params }
+      expect(Round.last.round_number).to eq(4)
+    end
+
+    it "既存の round を上書きできる" do
+      round = create(:round, game: game, round_number: 1)
+      players.each do |player|
+        create(:score, round: round, player: player, point: 10000)
+      end
+
+      expect {
+        post game_rounds_path(game), params: { round_number: 1, scores: scores_params }
+      }.not_to change(Round, :count)
+
+      expect(round.reload.scores.find_by(player: players[0]).point).to eq(25000)
+      expect(round.reload.scores.find_by(player: players[1]).point).to eq(30000)
+    end
+
+    it "4人分の点数が揃っていない場合は保存しない" do
+      incomplete_scores = scores_params.except(players[3].id.to_s)
+
+      expect {
+        post game_rounds_path(game), params: { round_number: 1, scores: incomplete_scores }
+      }.not_to change(Round, :count)
+
+      expect(response).to have_http_status(422)
+      expect(response.body).to include("入力内容を確認してください")
+    end
+
+    it "合計が100000点でない場合は保存しない" do
+      invalid_scores = scores_params.merge(players[3].id.to_s => "100")
+
+      expect {
+        post game_rounds_path(game), params: { round_number: 1, scores: invalid_scores }
+      }.not_to change(Round, :count)
+
+      expect(response).to have_http_status(422)
+      expect(response.body).to include("入力内容を確認してください")
+    end
+
+    it "入力範囲外の点数は保存しない" do
+      out_of_range_scores = scores_params.merge(players[2].id.to_s => "1001")
+
+      expect {
+        post game_rounds_path(game), params: { round_number: 1, scores: out_of_range_scores }
+      }.not_to change(Round, :count)
+
+      expect(response).to have_http_status(422)
+      expect(response.body).to include("入力内容を確認してください")
+    end
 
     it "スコア一覧にリダイレクトする" do
-      post game_rounds_path(game), params: { round_number: 1, scores: {} }
+      post game_rounds_path(game), params: { round_number: 1, scores: scores_params }
       expect(response).to redirect_to(game_path(game))
     end
   end


### PR DESCRIPTION
## Summary
- rounds#create で点数保存と round_number 自動採番を実装
- 4人入力・合計100000点・-1000〜1000範囲のバリデーションを追加
- 入力不備時はメッセージ表示と送信無効化

## Test plan
- [x] bundle exec rspec spec/requests/rounds_spec.rb

## Fixes
- Fixes #20