### PR TITLE
feat: database.yml と docker-compose.yml を環境変数対応にする

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -16,10 +16,10 @@ default: &default
   adapter: postgresql
   encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  host: db
-  port: 5432
-  username: postgres
-  password: password
+  host: <%= ENV.fetch("DATABASE_HOST", "db") %>
+  port: <%= ENV.fetch("DATABASE_PORT", "5432") %>
+  username: <%= ENV.fetch("DATABASE_USERNAME", "postgres") %>
+  password: <%= ENV.fetch("DATABASE_PASSWORD", "password") %>
 
 development:
   <<: *default
@@ -31,27 +31,4 @@ test:
 
 production:
   <<: *default
-  database: mahjong_score_production
-  username: postgres
-  password: <%= ENV.fetch("DATABASE_PASSWORD") %>
-  # The specified database role being used to connect to PostgreSQL.
-  # To create additional roles in PostgreSQL see `$ createuser --help`.
-  # When left blank, PostgreSQL will use the default role. This is
-  # the same name as the operating system user running Rails.
-  #username: app
-  # The password associated with the PostgreSQL role (username).
-  #password:
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  #host: localhost
-  # The TCP port the server listens on. Defaults to 5432.
-  # If your server runs on a different port number, change accordingly.
-  #port: 5432
-  # Schema search path. The server defaults to $user,public
-  #schema_search_path: myapp,sharedapp,public
-  # Minimum log levels, in increasing order:
-  #   debug5, debug4, debug3, debug2, debug1,
-  #   log, notice, warning, error, fatal, and panic
-  # Defaults to warning.
-  #min_messages: notice
+  database: <%= ENV.fetch("DATABASE_NAME", "mahjong_score_production") %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,10 +20,13 @@ services:
     ports:
       - "3000:3000"
     environment:
-      RAILS_ENV: development
-      DATABASE_HOST: db
-      DATABASE_USERNAME: postgres
-      DATABASE_PASSWORD: password
+      RAILS_ENV: ${RAILS_ENV:-development}
+      DATABASE_HOST: ${DATABASE_HOST:-db}
+      DATABASE_USERNAME: ${DATABASE_USERNAME:-postgres}
+      DATABASE_PASSWORD: ${DATABASE_PASSWORD:-password}
+      DATABASE_NAME: ${DATABASE_NAME:-mahjong_score_development}
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE:-}
+      RAILS_MASTER_KEY: ${RAILS_MASTER_KEY:-}
     command: bash -lc "bundle install && bin/rails s -b 0.0.0.0"
 
 volumes:


### PR DESCRIPTION
## Summary
- `config/database.yml` の DB 接続情報（host, port, username, password）を環境変数で切り替え可能にした
- `docker-compose.yml` の環境変数を `${VAR:-default}` 形式にし、`.env` や外部から上書きできるようにした
- AWS（EC2 + RDS）デプロイに向けた準備（Issue #27 Phase 1）

## Test plan
- [x] `docker compose exec web bundle exec rspec` — 全39テスト通過
- [x] ローカル環境（Docker Compose）で既存機能が壊れていないことを確認

## Fixes
- Fixes #27（Phase 1: コード修正）

🤖 Generated with [Claude Code](https://claude.com/claude-code)