### PR TITLE
fix: production環境のforce_sslを無効化

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,7 +49,7 @@ Rails.application.configure do
   # config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  # config.force_ssl = true
 
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new(STDOUT)


### PR DESCRIPTION
## Summary
- production環境の `config.force_ssl = true` をコメントアウト
- SSL証明書なしのEC2直接アクセス時にHTTPSリダイレクトループが発生する問題を修正

## Test plan
- [x] RSpec 39テスト全パス（development/test環境に影響なし）
- [ ] EC2上で `git pull` → コンテナ再起動後、`http://54.65.150.204:3000` にアクセスできることを確認

Fixes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production transport/security behavior by disabling automatic HTTPS enforcement, which could allow unintended HTTP traffic if not protected by a reverse proxy or network controls.
> 
> **Overview**
> Prevents production from forcibly redirecting all requests to HTTPS by commenting out `config.force_ssl = true` in `config/environments/production.rb`.
> 
> This changes production behavior to allow plain-HTTP access (e.g., when not behind an SSL-terminating proxy) and avoids redirect loops in such deployments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c979411ac6311e0025f80839b67fb935b58ff56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->