### PR TITLE
半荘の行数を10から8に変更

### DIFF
--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -11,7 +11,7 @@
       </tr>
     </thead>
     <tbody>
-      <% (1..10).each do |num| %>
+      <% (1..8).each do |num| %>
         <% round = @rounds.find { |r| r.round_number == num } %>
         <tr>
           <td><%= link_to num, new_game_round_path(@game, round_number: num) %></td>

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "Games", type: :request do
 
       it "行番号が点数入力画面へのリンクになっている" do
         get game_path(game)
-        (1..10).each do |num|
+        (1..8).each do |num|
           expect(response.body).to include(new_game_round_path(game, round_number: num))
         end
       end


### PR DESCRIPTION
## Summary
- 一般的な麻雀スコア記録帳に合わせて、スコア一覧画面の半荘行数を10行から8行に変更

## Test plan
- [x] 行番号リンクが1〜8のみ表示されることを確認
- [x] 全テスト（53件）パス

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> 表示行数とテスト範囲の調整のみで、データモデルや計算ロジックには触れていないため低リスクです。
> 
> **Overview**
> スコア一覧（`games#show`）で表示する半荘行数を **10→8** に変更し、点数入力画面へのリンクも `1..8` のみに制限しました。
> 
> あわせてリクエストスペックを更新し、`GET /games/:id` で `new_game_round_path` リンクが **1〜8のみ** 出力されることを検証するようにしました。
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54fb6a1bd991f42360791ccca0e69d41b2ac66f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->