### PR TITLE
fix: SECRET_KEY_BASE 環境変数を削除して起動エラーを修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,6 @@ services:
       DATABASE_USERNAME: ${DATABASE_USERNAME:-postgres}
       DATABASE_PASSWORD: ${DATABASE_PASSWORD:-password}
       DATABASE_NAME: ${DATABASE_NAME:-mahjong_score_development}
-      SECRET_KEY_BASE: ${SECRET_KEY_BASE:-}
       RAILS_MASTER_KEY: ${RAILS_MASTER_KEY:-}
     command: bash -lc "bundle install && bin/rails s -b 0.0.0.0"
 


### PR DESCRIPTION
## Summary
- `docker-compose.yml` から `SECRET_KEY_BASE: ${SECRET_KEY_BASE:-}` を削除
- 空文字がセットされることで Rails が `credentials.yml.enc` から `secret_key_base` を読み取れず起動に失敗していた
- `master.key` + `credentials.yml.enc` から自動取得する元の動作に戻す

## 原因
- 2/14 のコミット `6532400` で環境変数対応として追加された `SECRET_KEY_BASE: ${SECRET_KEY_BASE:-}` が原因
- コンテナが再作成されるまでは古い設定で動いていたため問題が表面化しなかった
- Docker Desktop 再起動後にコンテナが再作成され、空文字が適用されてエラーが発生

## Test plan
- [x] `docker compose up -d` で web コンテナが正常に起動することを確認済み
- [x] http://localhost:3000 でアクセスできることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)