### PR TITLE
chore: CLAUDE.mdにリリース手順とブランチプレフィックス運用を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,17 @@
 
 - mainブランチで直接開発しない
 - ブランチはissue単位で切る
+- ブランチ名のプレフィックスは最小構成で運用する（feature/ fix/ chore/）
 - PRのベースブランチは main にする（VSCode拡張の自動検出値より本設定を優先すること）
+
+## リリース手順
+
+1. PRをmainにマージする
+2. ローカルのmainを更新する（`git pull`）
+3. EC2にデプロイする
+4. 本番環境で動作確認する
+5. `config/initializers/version.rb` の `APP_VERSION` を更新する
+6. `gh release create` でタグを作成する
 
 ## 品質保証の考え方
 


### PR DESCRIPTION
## 変更内容

- `Git運用` セクションにブランチ名プレフィックスの運用方針を追加（feature/ fix/ chore/ の最小構成）
- `Git運用` セクションの後に `リリース手順` セクションを新設

## リリース手順（追加内容）

1. PRをmainにマージする
2. ローカルのmainを更新する（`git pull`）
3. EC2にデプロイする
4. 本番環境で動作確認する
5. `config/initializers/version.rb` の `APP_VERSION` を更新する
6. `gh release create` でタグを作成する