### PR TITLE
chore: .gitignoreに.claude/を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Ignore Claude Code worktrees and local AI tooling.
+/.claude/


### PR DESCRIPTION
## 変更内容

- `.gitignore` に `/.claude/` を追加
- Claude Code が自動生成するワークツリーディレクトリをgit管理対象外にする