### PR TITLE
feat: GitHub Actions CI ワークフローを追加する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: mahjong_score_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      RAILS_ENV: test
+      DATABASE_HOST: localhost
+      DATABASE_USERNAME: postgres
+      DATABASE_PASSWORD: password
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3.10"
+          bundler-cache: true
+
+      - name: DB setup
+        run: bin/rails db:create db:schema:load
+
+      - name: RSpec
+        run: bundle exec rspec


### PR DESCRIPTION
## 概要
closes #89

push / pull_request to main で RSpec を自動実行する CI ワークフローを追加。

## 変更内容
- `.github/workflows/ci.yml` を新規作成

## CI の動作
1. PostgreSQL 16 をサービスコンテナとして起動
2. Ruby 3.3.10 セットアップ（bundler キャッシュあり）
3. `db:create db:schema:load` でテスト DB 構築
4. `bundle exec rspec` を実行

## 検証方法
- このPRで GitHub Actions が自動実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)