### PR TITLE
feat: Claude Code Hooks を設定する

### DIFF
--- a/.claude/hooks/pre-push-test.sh
+++ b/.claude/hooks/pre-push-test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# git push 前に RSpec を実行し、失敗したら push をブロック
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if echo "$COMMAND" | grep -q "git push"; then
+  echo "RSpec を実行してから push します..." >&2
+
+  if ! docker compose -f "$CLAUDE_PROJECT_DIR/docker-compose.yml" exec -T web bundle exec rspec 2>&1; then
+    echo "" >&2
+    echo "テストが失敗しました。push をブロックします。" >&2
+    echo "先にテストを修正してください。" >&2
+    exit 2
+  fi
+
+  echo "テストがパスしました。push を続行します。" >&2
+fi
+
+exit 0

--- a/.claude/hooks/prevent-main-commit.sh
+++ b/.claude/hooks/prevent-main-commit.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# main ブランチへの直接コミット・push をブロック
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if echo "$COMMAND" | grep -qE "git (commit|push)"; then
+  CURRENT_BRANCH=$(git -C "$CLAUDE_PROJECT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null)
+
+  if [ "$CURRENT_BRANCH" = "main" ]; then
+    echo "Error: main ブランチへの直接 $(echo "$COMMAND" | grep -oE 'commit|push') は禁止されています。" >&2
+    echo "先に feature ブランチを切ってください: git checkout -b feature/your-feature" >&2
+    exit 2
+  fi
+fi
+
+exit 0

--- a/.claude/hooks/session-start-info.sh
+++ b/.claude/hooks/session-start-info.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# セッション開始時に git 状態とリモート差分を表示
+
+cd "$CLAUDE_PROJECT_DIR" || exit 0
+
+echo "=== Git Status ==="
+git status --short
+
+echo ""
+echo "=== Current Branch ==="
+git rev-parse --abbrev-ref HEAD
+
+echo ""
+echo "=== リモートとの差分 (origin/main との比較) ==="
+git fetch -q 2>/dev/null || true
+DIFF=$(git log HEAD..origin/main --oneline 2>/dev/null)
+if [ -n "$DIFF" ]; then
+  echo "$DIFF"
+else
+  echo "差分なし（最新状態）"
+fi
+
+exit 0

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "Rails (Docker Compose)",
+      "runtimeExecutable": "docker",
+      "runtimeArgs": ["compose", "up"],
+      "port": 3000
+    }
+  ]
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,33 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/prevent-main-commit.sh",
+            "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/pre-push-test.sh",
+            "timeout": 600
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start-info.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,5 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 
-# Ignore Claude Code worktrees and local AI tooling.
-/.claude/
+# Ignore Claude Code worktrees only (settings and hooks are tracked).
+/.claude/worktrees/


### PR DESCRIPTION
## 概要
closes #90

Claude Code の Hooks 機能で開発時の安全ネットを構築。

## 変更内容

### `.gitignore`
- `/.claude/` の除外を削除し、git 管理対象に変更
- `/.claude/worktrees/` のみ引き続き除外

### `.claude/settings.json`
- `PreToolUse`（Bash）と `SessionStart` フックを登録

### `.claude/hooks/`
| ファイル | 内容 |
|---|---|
| `prevent-main-commit.sh` | main への直接 commit / push をブロック |
| `pre-push-test.sh` | push 前に RSpec を実行、失敗時はブロック |
| `session-start-info.sh` | セッション開始時に git status とリモート差分を表示 |

## 検証方法
- Claude Code で main ブランチのまま `git commit` を試みる → ブロックされることを確認
- テスト失敗状態で `git push` を試みる → ブロックされることを確認
- 新しいセッション開始時に git 情報が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)