### PR TITLE
feat: GitHub MCP Server と Context7 MCP Server を設定する (#91)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "enableAllProjectMcpServers": true,
   "hooks": {
     "PreToolUse": [
       {

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    },
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `.mcp.json` を新規作成し、GitHub MCP Server（`@modelcontextprotocol/server-github`）と Context7 MCP Server（`@upstash/context7-mcp`）を追加
- `.claude/settings.json` に `enableAllProjectMcpServers: true` を追加してプロジェクトのMCPサーバーを自動承認

## 補足
- `GITHUB_PERSONAL_ACCESS_TOKEN` は環境変数から参照するため、事前にシェル環境に設定が必要
- Context7 は `use context7` と指示するだけで最新ドキュメントを取得可能

## Closes
- #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)