### PR TITLE
chore: git checkout -b の前に git pull を強制するフックを追加する

### DIFF
--- a/.claude/hooks/pre-branch-pull.sh
+++ b/.claude/hooks/pre-branch-pull.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# git checkout -b の前に git pull を実行する
+# 失敗した場合はブランチ作成をブロックする
+
+cmd=$(jq -r '.tool_input.command // ""')
+
+if echo "$cmd" | grep -q 'git checkout -b'; then
+  if ! git pull 2>&1; then
+    echo '{"continue": false, "stopReason": "git pull に失敗しました。最新化してからブランチを切ってください。"}'
+    exit 0
+  fi
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,12 @@
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/pre-push-test.sh",
             "timeout": 600
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/pre-branch-pull.sh",
+            "timeout": 30,
+            "statusMessage": "git pull で最新化しています..."
           }
         ]
       }


### PR DESCRIPTION
## 変更内容

`git checkout -b` を実行する前に自動で `git pull` を実行するフックを追加しました。

## 追加ファイル

- `.claude/hooks/pre-branch-pull.sh` — フックスクリプト
- `.claude/settings.json` — PreToolUse/Bash フックに登録

## 動作

1. Claude が `git checkout -b` を含む Bash コマンドを実行しようとすると、先に `git pull` を実行する
2. `git pull` が成功 → そのままブランチ作成へ進む
3. `git pull` が失敗 → ブランチ作成をブロックし「最新化してからブランチを切ってください」と表示する

## 目的

古い状態から分岐することによるマージコンフリクトを防ぐ。