### PR TITLE
chore: RDS バックアップ保持期間を 1日 → 7日 に延長する

### DIFF
--- a/infra/cloudformation.yml
+++ b/infra/cloudformation.yml
@@ -215,7 +215,7 @@ Resources:
         - !Ref RDSSecurityGroup
       DBSubnetGroupName: !Ref DBSubnetGroup
       PubliclyAccessible: false
-      BackupRetentionPeriod: 1
+      BackupRetentionPeriod: 7
       DeletionProtection: false
       Tags:
         - Key: Name


### PR DESCRIPTION
## 概要

closes #86

`infra/cloudformation.yml` の `BackupRetentionPeriod` を `1` → `7` に変更し、RDS 自動スナップショットの保持期間を延長する。

## 変更内容

- `BackupRetentionPeriod: 1` → `BackupRetentionPeriod: 7`

## 期待する効果

- 7日前までのデータに復旧できる
- Infrastructure as Code でバックアップ設定を管理できる

## 備考

- コスト増なし（RDS の自動スナップショットは DB 容量分まで無料）
- 既存データへの影響なし（保持日数の変更のみ）
- CloudFormation スタックの更新が必要（マージ後に実施）

## CloudFormation スタック更新手順

```bash
aws cloudformation update-stack \
  --stack-name <スタック名> \
  --use-previous-template \
  --parameters ParameterKey=<キー>,UsePreviousValue=true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)