### PR TITLE
feat: ゲーム画面にURL共有ボタンを追加する (#69)

### DIFF
--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -39,7 +39,32 @@
     </tfoot>
   </table>
 
+  <div class="share-section">
+    <button class="share-button" data-share-url="<%= game_url(@game) %>">
+      URLを共有する
+    </button>
+  </div>
+
   <div class="back-link">
     <%= link_to "← トップに戻る", root_path %>
   </div>
 </div>
+
+<script>
+  (function() {
+    var btn = document.querySelector('[data-share-url]');
+    if (!btn) return;
+
+    btn.addEventListener('click', function() {
+      var url = btn.dataset.shareUrl;
+      if (navigator.share) {
+        navigator.share({ title: '麻雀スコア', url: url });
+      } else {
+        navigator.clipboard.writeText(url).then(function() {
+          btn.textContent = 'コピーしました！';
+          setTimeout(function() { btn.textContent = 'URLを共有する'; }, 2000);
+        });
+      }
+    });
+  })();
+</script>

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -71,6 +71,13 @@ RSpec.describe "Games", type: :request do
       %w[Alice Bob Carol Dave].map { |name| create(:player, game: game, name: name) }
     end
 
+    context "共有ボタン" do
+      it "URLを共有するボタンが表示される" do
+        get game_path(game)
+        expect(response.body).to include('data-share-url')
+      end
+    end
+
     context "半荘データがない場合" do
       it "ステータス200が返る" do
         get game_path(game)


### PR DESCRIPTION
## 概要

closes #69

ゲーム作成後、同卓メンバーにURLをワンタップで共有できるボタンを追加しました。

## 変更内容

- `games/show` に「URLを共有する」ボタンを追加
- Web Share API 対応端末（iOS Safari / Android Chrome）は `navigator.share()` でLINE等に直接共有
- 非対応端末は `navigator.clipboard.writeText()` でURLコピー → 2秒間「コピーしました！」表示
- Request Spec で共有ボタンの表示確認テストを追加

## テスト

- [x] `GET /games/:id` で `data-share-url` 属性を持つボタンが表示されること（Request Spec）