### PR TITLE
fix: HTTP環境でもURLコピーが動くようにフォールバックを追加する

### DIFF
--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -60,10 +60,18 @@
       if (navigator.share) {
         navigator.share({ title: '麻雀スコア', url: url });
       } else {
-        navigator.clipboard.writeText(url).then(function() {
+        var textarea = document.createElement('textarea');
+        textarea.value = url;
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.select();
+        try {
+          document.execCommand('copy');
           btn.textContent = 'コピーしました！';
           setTimeout(function() { btn.textContent = 'URLを共有する'; }, 2000);
-        });
+        } catch (e) {}
+        document.body.removeChild(textarea);
       }
     });
   })();


### PR DESCRIPTION
## 概要

本番 HTTP 環境で「URLを共有する」ボタンを押しても「コピーしました！」が表示されないバグを修正。

## 原因

`navigator.clipboard.writeText()` は HTTPS 限定の API のため、HTTP 環境では動作しない。

## 修正内容

`document.execCommand('copy')` に置き換え。HTTP / HTTPS どちらでも動作する。

## 動作フロー

```
ボタンをタップ
  ↓
navigator.share が使える？（スマホのLINE共有など）
  YES → navigator.share() で直接共有
  NO  → document.execCommand('copy') でURLをコピー → 「コピーしました！」表示
```