### PR TITLE
feat: CloudWatch AgentをEC2にインストール・設定する

### DIFF
--- a/infra/cloudformation.yml
+++ b/infra/cloudformation.yml
@@ -222,7 +222,34 @@ Resources:
           Value: mahjong-score-rds
 
   # ----------------------------------------------------------
-  # 7. EC2 — Railsアプリを動かすサーバー
+  # 7. IAM Role — EC2にCloudWatch書き込み権限を付与
+  # ----------------------------------------------------------
+  EC2InstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: mahjong-score-ec2-role
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
+      Tags:
+        - Key: Name
+          Value: mahjong-score-ec2-role
+
+  EC2InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      InstanceProfileName: mahjong-score-ec2-profile
+      Roles:
+        - !Ref EC2InstanceRole
+
+  # ----------------------------------------------------------
+  # 8. EC2 — Railsアプリを動かすサーバー
   # ----------------------------------------------------------
   EC2Instance:
     Type: AWS::EC2::Instance
@@ -234,6 +261,7 @@ Resources:
       SubnetId: !Ref PublicSubnet
       SecurityGroupIds:
         - !Ref EC2SecurityGroup
+      IamInstanceProfile: !Ref EC2InstanceProfile
       Tags:
         - Key: Name
           Value: mahjong-score-ec2
@@ -292,6 +320,58 @@ Resources:
           echo "=== アセットプリコンパイル ==="
           /usr/local/bin/docker-compose exec -T web bash -lc \
             "bin/rails assets:precompile RAILS_ENV=production"
+
+          echo "=== CloudWatch Agent インストール ==="
+          yum install -y amazon-cloudwatch-agent
+
+          echo "=== CloudWatch Agent 設定ファイル作成 ==="
+          mkdir -p /opt/aws/amazon-cloudwatch-agent/etc
+          cat <<'CWEOF' > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+          {
+            "agent": {
+              "metrics_collection_interval": 60,
+              "run_as_user": "root"
+            },
+            "metrics": {
+              "metrics_collected": {
+                "mem": {
+                  "measurement": ["mem_used_percent"],
+                  "metrics_collection_interval": 60
+                },
+                "disk": {
+                  "measurement": ["disk_used_percent"],
+                  "resources": ["/"],
+                  "metrics_collection_interval": 60
+                }
+              },
+              "append_dimensions": {
+                "InstanceId": "${!aws:InstanceId}"
+              }
+            },
+            "logs": {
+              "logs_collected": {
+                "files": {
+                  "collect_list": [
+                    {
+                      "file_path": "/home/ec2-user/mahjong_score/log/production.log",
+                      "log_group_name": "/mahjong-score/rails/production",
+                      "log_stream_name": "{instance_id}",
+                      "timezone": "Asia/Tokyo"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+          CWEOF
+
+          echo "=== CloudWatch Agent 起動 ==="
+          /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
+            -a fetch-config \
+            -m ec2 \
+            -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json \
+            -s
+          systemctl enable amazon-cloudwatch-agent
 
           echo "=== 完了 ==="
 


### PR DESCRIPTION
## 対応イシュー
- closes #111
- closes #112（production.log の転送を同時対応）

## 変更内容

### 追加したリソース
- `EC2InstanceRole` — `CloudWatchAgentServerPolicy` をアタッチした IAM Role
- `EC2InstanceProfile` — EC2 に Role を紐づける InstanceProfile
- `EC2Instance` に `IamInstanceProfile` を追加

### UserData に追加した処理
1. `amazon-cloudwatch-agent` をインストール
2. Agent 設定ファイルを配置（`/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json`）
   - メモリ・ディスク使用率を60秒間隔で収集
   - `production.log` を `/mahjong-score/rails/production` ロググループに転送
3. Agent を起動・自動起動設定

## 確認方法
1. CloudFormation スタックを更新する
2. EC2 に SSH して `systemctl status amazon-cloudwatch-agent` でAgent が起動していることを確認
3. AWS コンソール > CloudWatch > ロググループ に `/mahjong-score/rails/production` が表示されることを確認
4. AWS コンソール > CloudWatch > メトリクス > CWAgent にメモリ・ディスクのメトリクスが届いていることを確認