### PR TITLE
feat: RDSのPostgreSQLログ出力を有効化する

### DIFF
--- a/infra/cloudformation.yml
+++ b/infra/cloudformation.yml
@@ -190,6 +190,21 @@ Resources:
   # 6. RDS — PostgreSQLデータベース
   # ----------------------------------------------------------
 
+  # PostgreSQLログ出力設定（スロークエリ・エラーログ）
+  DBParameterGroup:
+    Type: AWS::RDS::DBParameterGroup
+    Properties:
+      Description: "Mahjong Score - PostgreSQL log settings"
+      Family: postgres16
+      Parameters:
+        log_min_duration_statement: "1000"  # 1秒以上のクエリをスロークエリとして記録
+        log_connections: "1"
+        log_disconnections: "1"
+        log_error_verbosity: "default"
+      Tags:
+        - Key: Name
+          Value: mahjong-score-db-params
+
   # RDSを置くSubnetの組み合わせ（2つのAZ必須）
   DBSubnetGroup:
     Type: AWS::RDS::DBSubnetGroup
@@ -214,6 +229,9 @@ Resources:
       VPCSecurityGroups:
         - !Ref RDSSecurityGroup
       DBSubnetGroupName: !Ref DBSubnetGroup
+      DBParameterGroupName: !Ref DBParameterGroup
+      EnableCloudwatchLogsExports:
+        - postgresql
       PubliclyAccessible: false
       BackupRetentionPeriod: 7
       DeletionProtection: false


### PR DESCRIPTION
## 対応イシュー
- closes #113

## 変更内容

### 追加したリソース
- `DBParameterGroup`（Family: postgres16）
  - `log_min_duration_statement: 1000` — 1秒以上のクエリをスロークエリとして記録
  - `log_connections` / `log_disconnections` — 接続・切断ログを記録
  - `log_error_verbosity: default` — エラーログを出力

### RDSInstance に追加
- `DBParameterGroupName` — パラメータグループを紐づけ
- `EnableCloudwatchLogsExports: [postgresql]` — CloudWatch Logs への自動転送を有効化

## 確認方法
1. CloudFormation スタックを更新する
2. AWS コンソール > CloudWatch > ロググループ に `/aws/rds/instance/mahjong-score-db/postgresql` が表示されることを確認
3. アプリを操作して1秒以上かかるクエリがあればスロークエリとして記録されることを確認