### PR TITLE
feat: Railsログをawslogsドライバー経由でCloudWatch Logsに送る

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,8 @@
+services:
+  web:
+    logging:
+      driver: awslogs
+      options:
+        awslogs-region: ap-northeast-1
+        awslogs-group: /mahjong-score/rails/production
+        awslogs-create-group: "true"

--- a/infra/cloudformation.yml
+++ b/infra/cloudformation.yml
@@ -328,7 +328,7 @@ Resources:
           chown -R ec2-user:ec2-user /home/ec2-user/mahjong_score
 
           echo "=== Docker Compose 起動 ==="
-          /usr/local/bin/docker-compose --env-file .env up -d
+          /usr/local/bin/docker-compose -f docker-compose.yml -f docker-compose.production.yml --env-file .env up -d
 
           echo "=== DB セットアップ（起動待ち） ==="
           sleep 30
@@ -364,20 +364,6 @@ Resources:
               },
               "append_dimensions": {
                 "InstanceId": "${!aws:InstanceId}"
-              }
-            },
-            "logs": {
-              "logs_collected": {
-                "files": {
-                  "collect_list": [
-                    {
-                      "file_path": "/home/ec2-user/mahjong_score/log/production.log",
-                      "log_group_name": "/mahjong-score/rails/production",
-                      "log_stream_name": "{instance_id}",
-                      "timezone": "Asia/Tokyo"
-                    }
-                  ]
-                }
               }
             }
           }


### PR DESCRIPTION
## 対応イシュー
- closes #111
- closes #112

## 変更内容
- `docker-compose.production.yml` を追加
  - web サービスに `awslogs` ドライバーを設定
  - ロググループ: `/mahjong-score/rails/production`
- CloudFormation UserData の起動コマンドを production override を使う形に変更
- CloudWatch Agent 設定からログ転送を削除（awslogs ドライバーに移行）

## 背景
Rails ログはファイルではなく Docker の標準出力に出力されるため、
CloudWatch Agent によるファイル監視では収集できなかった。
awslogs ドライバーを使うことでコンテナのログを直接 CloudWatch Logs に送るよう変更。

## 確認済み
- `/mahjong-score/rails/production` ロググループが CloudWatch に表示されることを確認 ✅