### PR TITLE
feat: CloudWatchアラームとSNSメール通知を設定する

### DIFF
--- a/infra/cloudformation.yml
+++ b/infra/cloudformation.yml
@@ -34,6 +34,7 @@ Parameters:
 
   NotificationEmail:
     Type: String
+    Default: "tsukamotohiroaki0721+mahjong_score@gmail.com"
     Description: "アラーム通知先のメールアドレス"
 
 # ==============================================================


### PR DESCRIPTION
## 対応イシュー
- closes #114

## 変更内容
- `NotificationEmail` パラメータを追加（デフォルト値設定済み）
- `SNSAlarmTopic` / `SNSAlarmSubscription` を追加（メール通知）
- CloudWatch アラームを3つ追加
  - CPU使用率 80% が5分継続（`AWS/EC2` メトリクス）
  - メモリ使用率 80%（`CWAgent` カスタムメトリクス）
  - ディスク使用率 80%（`CWAgent` カスタムメトリクス、`/dev/xvda1` / `xfs`）

## デプロイ後の確認手順
1. CloudFormation スタックを更新する
2. 通知先メールアドレスに AWS からサブスクリプション確認メールが届くので「Confirm subscription」をクリックする
3. AWS コンソール > CloudWatch > アラーム に3つのアラームが表示されることを確認する