### PR TITLE
chore: NotificationEmailのデフォルト値を削除する

### DIFF
--- a/infra/cloudformation.yml
+++ b/infra/cloudformation.yml
@@ -34,7 +34,6 @@ Parameters:
 
   NotificationEmail:
     Type: String
-    Default: "tsukamotohiroaki0721+mahjong_score@gmail.com"
     Description: "アラーム通知先のメールアドレス"
 
 # ==============================================================


### PR DESCRIPTION
メールアドレスをハードコーディングしないよう、
Default値を削除してデプロイ時にパラメータで渡す形に変更する

## Summary
- 

## Test plan
- [ ] 

## Fixes
- Fixes #
