### PR TITLE
chore: EC2再起動時にDockerコンテナを自動起動するsystemdサービスを設定する

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,33 @@ mahjong_score/
 └── Gemfile             # gem 定義
 ```
 
+## 本番環境（AWS）
+
+### 構成
+
+- EC2（t2.micro）+ RDS（PostgreSQL 16）
+- CloudFormation でインフラをコード化（`infra/cloudformation.yml`）
+- Docker Compose で Rails アプリを起動
+
+### デプロイ手順
+
+1. EC2 に SSH 接続する
+2. アプリを更新する（`git pull`）
+3. コンテナを再起動する（`docker-compose up -d`）
+4. 本番環境で動作確認する
+
+### systemd サービスの設定（初回のみ）
+
+EC2 再起動時にアプリが自動起動するよう設定する：
+
+```bash
+sudo cp infra/mahjong-score.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable mahjong-score
+```
+
+※ CloudFormation で新規構築した場合は UserData で自動設定済み
+
 ## トラブルシューティング
 
 ### `localhost:3000` にアクセスできない

--- a/infra/cloudformation.yml
+++ b/infra/cloudformation.yml
@@ -381,6 +381,11 @@ Resources:
             -s
           systemctl enable amazon-cloudwatch-agent
 
+          echo "=== systemd サービス設定 ==="
+          cp /home/ec2-user/mahjong_score/infra/mahjong-score.service /etc/systemd/system/
+          systemctl daemon-reload
+          systemctl enable mahjong-score
+
           echo "=== 完了 ==="
 
   # ----------------------------------------------------------

--- a/infra/mahjong-score.service
+++ b/infra/mahjong-score.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Mahjong Score Application
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+User=ec2-user
+WorkingDirectory=/home/ec2-user/mahjong_score
+ExecStart=/usr/local/bin/docker-compose -f docker-compose.yml -f docker-compose.production.yml --env-file .env up -d
+ExecStop=/usr/local/bin/docker-compose -f docker-compose.yml -f docker-compose.production.yml down
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- `infra/mahjong-score.service` を新規作成（systemdサービス定義）
- `infra/cloudformation.yml` の UserData に systemd 設定を追加（`echo "=== 完了 ==="` の直前）
- `README.md` に「本番環境（AWS）」セクションを追加（構成・デプロイ手順・systemd初回設定手順）

## Test plan

- [ ] EC2再起動後、手動操作なしでアプリにアクセスできることを確認（デプロイ時に手動確認）

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)