### PR TITLE
chore: player_spec.rb の pending を解消する

### DIFF
--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -1,5 +1,32 @@
 require 'rails_helper'
 
 RSpec.describe Player, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "バリデーション" do
+    it "name が存在する場合は有効である" do
+      player = build(:player, name: "Alice")
+      expect(player).to be_valid
+    end
+
+    it "name が空の場合は無効である" do
+      player = build(:player, name: "")
+      expect(player).not_to be_valid
+    end
+
+    it "name が nil の場合は無効である" do
+      player = build(:player, name: nil)
+      expect(player).not_to be_valid
+    end
+  end
+
+  describe "アソシエーション" do
+    it "Game に belongs_to している" do
+      player = create(:player)
+      expect(player.game).to be_a(Game)
+    end
+
+    it "Game がない場合は無効である" do
+      player = build(:player, game: nil)
+      expect(player).not_to be_valid
+    end
+  end
 end


### PR DESCRIPTION
## 概要

closes #122

## 変更内容

`player_spec.rb` の pending を削除し、以下のテストを追加した。

- `name` の presence バリデーション（存在する / 空 / nil）
- `Game` への `belongs_to` アソシエーション（正常 / game が nil の場合）

## テスト結果

```
5 examples, 0 failures
```