### PR TITLE
chore: games#create のバリデーション失敗パスを補強する

### DIFF
--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -2,4 +2,5 @@ class Player < ApplicationRecord
   belongs_to :game
   has_many :scores
   validates :name, presence: true
+  validates :name, uniqueness: { scope: :game_id }
 end

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -82,6 +82,40 @@ RSpec.describe "Games", type: :request do
         }.to change(Game, :count).by(0).and change(Player, :count).by(0)
       end
     end
+
+    context "プレイヤー名が重複している場合" do
+      let(:players) { ["Player1", "Player1", "Player3", "Player4"] }
+
+      it "Game と Player が作成されない" do
+        expect {
+          post games_path, params: { players: players }
+        }.to change(Game, :count).by(0).and change(Player, :count).by(0)
+      end
+
+      it "メンバー入力画面にリダイレクトする" do
+        post games_path, params: { players: players }
+        expect(response).to redirect_to(new_game_path)
+      end
+    end
+
+    context "ゼロサム条件を満たさないルール設定の場合" do
+      let(:players) { ["Player1", "Player2", "Player3", "Player4"] }
+      let(:invalid_rule_params) do
+        { mochi_ten: 25000, kaeshi_ten: 30000,
+          rank_1_bonus: 50, rank_2_bonus: 10, rank_3_bonus: -10, rank_4_bonus: -10 }
+      end
+
+      it "Game が作成されない" do
+        expect {
+          post games_path, params: { players: players, game: invalid_rule_params }
+        }.to change(Game, :count).by(0)
+      end
+
+      it "メンバー入力画面にリダイレクトする" do
+        post games_path, params: { players: players, game: invalid_rule_params }
+        expect(response).to redirect_to(new_game_path)
+      end
+    end
   end
 
   describe "GET /games/:id" do


### PR DESCRIPTION
## 概要

closes #124

## 変更内容

**モデル**
- `Player` に `validates :name, uniqueness: { scope: :game_id }` を追加
  - 同じゲーム内でプレイヤー名が重複する場合に `RecordInvalid` が発生するようにした

**テスト**
- プレイヤー名が重複している場合: Game・Player が作成されず、メンバー入力画面にリダイレクト
- ゼロサム条件を満たさないルール設定の場合: Game が作成されず、メンバー入力画面にリダイレクト

## テスト結果

```
23 examples, 0 failures
```