### PR TITLE
E2Eテストに Playwright を導入する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,8 @@
 
 # Ignore Claude Code worktrees only (settings and hooks are tracked).
 /.claude/worktrees/
+
+# Node.js / Playwright
+/node_modules/
+/test-results/
+/playwright-report/

--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ docker compose exec web bin/rails routes
 
 # RSpec実行
 docker compose run --rm -e RAILS_ENV=test web bash -lc "bundle install && bundle exec rspec"
+
+# E2Eテスト実行（ホスト）※ 事前に docker compose up でアプリを起動しておく
+npx playwright test
+
+# E2Eテスト実行（Docker）
+docker compose run --rm playwright
 ```
 
 ### その他
@@ -112,6 +118,7 @@ mahjong_score/
 ├── db/
 │   ├── migrate/        # マイグレーションファイル
 │   └── schema.rb       # スキーマ定義
+├── e2e/                # E2Eテスト（Playwright）
 ├── docker-compose.yml  # Docker Compose 設定
 └── Gemfile             # gem 定義
 ```

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,4 +73,6 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  config.hosts << "web"
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,5 +28,18 @@ services:
       RAILS_MASTER_KEY: ${RAILS_MASTER_KEY:-}
     command: bash -lc "bundle install && bin/rails s -b 0.0.0.0"
 
+  playwright:
+    image: mcr.microsoft.com/playwright:v1.59.1-noble
+    depends_on:
+      - web
+    working_dir: /app
+    volumes:
+      - .:/app
+    environment:
+      BASE_URL: http://web:3000
+    command: bash -lc "npm ci && npx playwright test"
+    profiles:
+      - e2e
+
 volumes:
   postgres_data:

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from "@playwright/test";
+
+test("トップページが表示される", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page).toHaveTitle("App");
+  await expect(page.getByRole("heading", { name: "麻雀スコア管理アプリ" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "新しく始める" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "つづきから" })).toBeVisible();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "mahjong_score",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mahjong_score",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.59.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "mahjong_score",
+  "private": true,
+  "scripts": {
+    "test:e2e": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.59.1"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  use: {
+    baseURL: process.env.BASE_URL || "http://localhost:3000",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { browserName: "chromium" },
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

- Playwright + Chromium を導入し、E2E テストの基盤を構築
- トップページ表示のサンプルテスト（`e2e/home.spec.ts`）を作成
- ホスト / Docker 両方でテスト実行可能

## 変更内容

- `package.json` / `playwright.config.ts` — Playwright セットアップ
- `e2e/home.spec.ts` — サンプルテスト（タイトル・見出し・ボタンの表示確認）
- `docker-compose.yml` — `playwright` サービス追加（`profiles: [e2e]` で通常起動には影響なし）
- `config/environments/development.rb` — Docker 内部ホスト名 `web` を HostAuthorization に許可
- `.gitignore` — `node_modules/`, `test-results/`, `playwright-report/` を追加
- `README.md` — E2E テスト実行方法を追記

## Test plan

- [x] Playwright がインストール・設定されている
- [x] `e2e/` ディレクトリが作成されている
- [x] トップページ表示のサンプルテストがローカルで実行・パスする（`npx playwright test`）
- [x] Docker環境でも実行できる（`docker compose run --rm playwright`）
- [x] README に Playwright の実行方法が追記されている

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)