### PR TITLE
feat: Hotwire（importmap + Turbo + Stimulus）をセットアップする

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,65 @@ docker compose logs -f web
 docker compose exec web bundle install
 ```
 
+## Hotwire（Turbo + Stimulus）
+
+Rails 標準の Hotwire スタックを使用しています。
+
+### 構成
+
+- **importmap-rails**: JSモジュールの配信（バンドラー不要）
+- **Turbo**: ページ遷移の高速化（Turbo Drive）
+- **Stimulus**: HTML属性ベースの軽量JSフレームワーク
+
+### Stimulus コントローラーの追加方法
+
+```bash
+# コントローラーを作成
+docker compose exec web bin/rails generate stimulus controller_name
+```
+
+`app/javascript/controllers/` にファイルが生成されます。
+
+### ファイル構成
+
+```
+app/javascript/
+├── application.js                 # エントリーポイント（Turbo + Stimulus を読み込み）
+└── controllers/
+    ├── application.js             # Stimulus アプリケーション設定
+    ├── index.js                   # コントローラーの自動読み込み
+    └── hello_controller.js        # サンプルコントローラー
+config/
+└── importmap.rb                   # JSモジュールのピン定義
+```
+
+### Stimulus コントローラーの使い方
+
+```erb
+<!-- ビューで data-controller 属性を指定 -->
+<div data-controller="hello">
+  <!-- connect() 時に "Hello World!" に置き換わる -->
+</div>
+```
+
+```javascript
+// app/javascript/controllers/hello_controller.js
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.element.textContent = "Hello World!"
+  }
+}
+```
+
 ## ディレクトリ構成（主要部分）
 
 ```
 mahjong_score/
 ├── app/
 │   ├── controllers/    # コントローラー
+│   ├── javascript/     # JS（Stimulus コントローラー等）
 │   ├── models/         # モデル
 │   └── views/          # ビュー
 ├── config/

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,4 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
+//= link_tree ../../javascript .js
+//= link_tree ../../../vendor/javascript .js

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,0 +1,3 @@
+// Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
+import "@hotwired/turbo-rails"
+import "controllers"

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,0 +1,9 @@
+import { Application } from "@hotwired/stimulus"
+
+const application = Application.start()
+
+// Configure Stimulus development experience
+application.debug = false
+window.Stimulus   = application
+
+export { application }

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.element.textContent = "Hello World!"
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,0 +1,4 @@
+// Import and register all your controllers from the importmap via controllers/**/*_controller
+import { application } from "controllers/application"
+import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
+eagerLoadControllersFrom("controllers", application)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= javascript_importmap_tags %>
   </head>
 
   <body>

--- a/bin/importmap
+++ b/bin/importmap
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+
+require_relative "../config/application"
+require "importmap/commands"

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,0 +1,7 @@
+# Pin npm packages by running ./bin/importmap
+
+pin "application"
+pin "@hotwired/turbo-rails", to: "turbo.min.js"
+pin "@hotwired/stimulus", to: "stimulus.min.js"
+pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
+pin_all_from "app/javascript/controllers", under: "controllers"


### PR DESCRIPTION
## Summary

- Gemfile に記載済みだった importmap-rails / turbo-rails / stimulus-rails の3つのインストーラーを実行し、Hotwire を実際に動作する状態にした
- `app/javascript/controllers/` ディレクトリ、`config/importmap.rb`、`bin/importmap` 等が生成され、JS を読み込む基盤が整った
- サンプルの `hello_controller.js` を含む

## 変更内容

- `rails importmap:install` — importmap の基盤構築（`config/importmap.rb`、`bin/importmap`、レイアウトへの `javascript_importmap_tags` 追加）
- `rails turbo:install` — Turbo を importmap 経由で読み込む設定
- `rails stimulus:install` — Stimulus のセットアップ + `hello_controller.js` 生成
- README に Hotwire の概要・使い方・ファイル構成を追記

## Test plan

- [x] `config/importmap.rb` が生成されている
- [x] `bin/importmap` binstub が生成されている
- [x] `app/javascript/controllers/` ディレクトリが作成されている
- [x] レイアウトに `javascript_importmap_tags` が追加されている
- [x] `application.js` から Turbo と Stimulus が読み込まれている
- [x] RSpec 66 examples, 0 failures
- [x] Playwright 1 passed
- [ ] サンプルコントローラー（`hello_controller.js`）がブラウザで動作する（手動確認）
- [x] README に Hotwire の概要と使い方が追記されている

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)