### PR TITLE
feat: 点数入力画面のインラインJSをStimulusコントローラーに切り出す

### DIFF
--- a/app/javascript/controllers/score_input_controller.js
+++ b/app/javascript/controllers/score_input_controller.js
@@ -1,0 +1,94 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input", "totalOutput", "submitButton", "validationMessage"]
+
+  static values = {
+    targetTotal: { type: Number, default: 100000 },
+    unitScale: { type: Number, default: 100 },
+    minUnit: { type: Number, default: -1000 },
+    maxUnit: { type: Number, default: 1000 }
+  }
+
+  connect() {
+    this.hasInteracted = false
+    this.update()
+  }
+
+  onInput(event) {
+    this.hasInteracted = true
+    const input = event.target
+    input.dataset.manual = "true"
+    if (input.dataset.auto === "true") delete input.dataset.auto
+    this.update()
+  }
+
+  get targetUnits() {
+    return this.targetTotalValue / this.unitScaleValue
+  }
+
+  parseValue(value) {
+    if (value == null) return null
+    const trimmed = value.trim()
+    if (trimmed === "") return null
+    const number = Number(trimmed)
+    if (!Number.isFinite(number)) return null
+    return Math.trunc(number)
+  }
+
+  sumUnits(skipInput = null) {
+    return this.inputTargets.reduce((sum, input) => {
+      if (input === skipInput) return sum
+      const value = this.parseValue(input.value)
+      return value == null ? sum : sum + value
+    }, 0)
+  }
+
+  countFilled(skipInput = null) {
+    return this.inputTargets.filter(
+      (input) => input !== skipInput && this.parseValue(input.value) != null
+    ).length
+  }
+
+  update() {
+    const inputs = this.inputTargets
+    const autoInput = inputs.find((input) => input.dataset.auto === "true")
+    let targetInput = null
+
+    if (autoInput && this.countFilled(autoInput) === inputs.length - 1) {
+      targetInput = autoInput
+    } else if (!autoInput && this.countFilled() === inputs.length - 1) {
+      const emptyInput = inputs.find((input) => this.parseValue(input.value) == null)
+      if (emptyInput && emptyInput.dataset.manual !== "true") {
+        targetInput = emptyInput
+      }
+    }
+
+    if (targetInput) {
+      const remaining = this.targetUnits - this.sumUnits(targetInput)
+      targetInput.value = String(remaining)
+      targetInput.dataset.auto = "true"
+      delete targetInput.dataset.manual
+    } else if (autoInput && autoInput.dataset.manual !== "true") {
+      autoInput.value = ""
+      delete autoInput.dataset.auto
+    }
+
+    const totalUnits = this.sumUnits()
+    this.totalOutputTarget.textContent = String(totalUnits * this.unitScaleValue)
+
+    if (this.hasSubmitButtonTarget) {
+      const allFilled = inputs.every((input) => this.parseValue(input.value) != null)
+      const inRange = inputs.every((input) => {
+        const value = this.parseValue(input.value)
+        return value == null || (value >= this.minUnitValue && value <= this.maxUnitValue)
+      })
+      const isValid = allFilled && totalUnits === this.targetUnits && inRange
+      this.submitButtonTarget.disabled = !isValid
+      this.submitButtonTarget.classList.toggle("is-disabled", !isValid)
+      if (this.hasValidationMessageTarget) {
+        this.validationMessageTarget.hidden = isValid || !this.hasInteracted
+      }
+    }
+  }
+}

--- a/app/views/rounds/new.html.erb
+++ b/app/views/rounds/new.html.erb
@@ -6,7 +6,8 @@
       <div class="form-error" role="alert"><%= @error_message %></div>
     <% end %>
 
-    <%= form_with url: game_rounds_path(@game), method: :post, local: true, class: "rounds-form" do %>
+    <%= form_with url: game_rounds_path(@game), method: :post, local: true, class: "rounds-form",
+                  data: { controller: "score-input" } do %>
       <% if @round_number.present? %>
         <%= hidden_field_tag :round_number, @round_number %>
       <% end %>
@@ -35,7 +36,8 @@
                                      pattern: "-?[0-9]*",
                                      autocomplete: "off",
                                      maxlength: 5,
-                                     class: "score-input" %>
+                                     class: "score-input",
+                                     data: { score_input_target: "input", action: "input->score-input#onInput" } %>
                   <span class="score-unit score-unit--hundreds">00点</span>
                 </div>
               </td>
@@ -46,7 +48,7 @@
           <tr class="score-total">
             <th>合計</th>
             <td class="score-total-value">
-              <span data-total-output>0</span>
+              <span data-score-input-target="totalOutput">0</span>
               <span class="score-unit">点</span>
             </td>
           </tr>
@@ -54,8 +56,9 @@
       </table>
 
       <div class="form-actions">
-        <%= submit_tag "入力完了", class: "btn btn-primary rounds-submit" %>
-        <p class="validation-message" data-validation-message hidden>入力内容を確認してください</p>
+        <%= submit_tag "入力完了", class: "btn btn-primary rounds-submit",
+                       data: { score_input_target: "submitButton" } %>
+        <p class="validation-message" data-score-input-target="validationMessage" hidden>入力内容を確認してください</p>
       </div>
     <% end %>
   </div>
@@ -64,94 +67,3 @@
     <%= link_to "← スコア一覧に戻る", game_path(@game) %>
   </div>
 </div>
-
-<script>
-  (() => {
-    const form = document.querySelector(".rounds-form");
-    if (!form) return;
-
-    const inputs = Array.from(form.querySelectorAll(".score-input"));
-    const totalOutput = form.querySelector("[data-total-output]");
-    const submitButton = form.querySelector(".rounds-submit");
-    const validationMessage = form.querySelector("[data-validation-message]");
-    let hasInteracted = false;
-    if (inputs.length === 0 || !totalOutput) return;
-
-    const TARGET_TOTAL = 100000;
-    const UNIT_SCALE = 100;
-    const TARGET_UNITS = TARGET_TOTAL / UNIT_SCALE;
-    const MIN_UNIT = -1000;
-    const MAX_UNIT = 1000;
-
-    const parseValue = (value) => {
-      if (value == null) return null;
-      const trimmed = value.trim();
-      if (trimmed === "") return null;
-      const number = Number(trimmed);
-      if (!Number.isFinite(number)) return null;
-      return Math.trunc(number);
-    };
-
-    const sumUnits = (skipInput = null) =>
-      inputs.reduce((sum, input) => {
-        if (input === skipInput) return sum;
-        const value = parseValue(input.value);
-        return value == null ? sum : sum + value;
-      }, 0);
-
-    const countFilled = (skipInput = null) =>
-      inputs.filter((input) => input !== skipInput && parseValue(input.value) != null).length;
-
-    const update = () => {
-      const autoInput = inputs.find((input) => input.dataset.auto === "true");
-      let targetInput = null;
-
-      if (autoInput && countFilled(autoInput) === inputs.length - 1) {
-        targetInput = autoInput;
-      } else if (!autoInput && countFilled() === inputs.length - 1) {
-        const emptyInput = inputs.find((input) => parseValue(input.value) == null);
-        if (emptyInput && emptyInput.dataset.manual !== "true") {
-          targetInput = emptyInput;
-        }
-      }
-
-      if (targetInput) {
-        const remaining = TARGET_UNITS - sumUnits(targetInput);
-        targetInput.value = String(remaining);
-        targetInput.dataset.auto = "true";
-        delete targetInput.dataset.manual;
-      } else if (autoInput && autoInput.dataset.manual !== "true") {
-        autoInput.value = "";
-        delete autoInput.dataset.auto;
-      }
-
-      const totalUnits = sumUnits();
-      totalOutput.textContent = String(totalUnits * UNIT_SCALE);
-
-      if (submitButton) {
-        const allFilled = inputs.every((input) => parseValue(input.value) != null);
-        const inRange = inputs.every((input) => {
-          const value = parseValue(input.value);
-          return value == null || (value >= MIN_UNIT && value <= MAX_UNIT);
-        });
-        const isValid = allFilled && totalUnits === TARGET_UNITS && inRange;
-        submitButton.disabled = !isValid;
-        submitButton.classList.toggle("is-disabled", !isValid);
-        if (validationMessage) {
-          validationMessage.hidden = isValid || !hasInteracted;
-        }
-      }
-    };
-
-    inputs.forEach((input) => {
-      input.addEventListener("input", () => {
-        hasInteracted = true;
-        input.dataset.manual = "true";
-        if (input.dataset.auto === "true") delete input.dataset.auto;
-        update();
-      });
-    });
-
-    update();
-  })();
-</script>

--- a/e2e/score_input.spec.ts
+++ b/e2e/score_input.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect, Page } from "@playwright/test";
+
+async function createGameAndGoToScoreInput(page: Page) {
+  await page.goto("/games/new");
+  await page.getByLabel("プレイヤー1").fill("Alice");
+  await page.getByLabel("プレイヤー2").fill("Bob");
+  await page.getByLabel("プレイヤー3").fill("Carol");
+  await page.getByLabel("プレイヤー4").fill("Dave");
+  await page.getByRole("button", { name: "ゲーム開始" }).click();
+
+  await page.getByRole("link", { name: "1", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "点数入力" })).toBeVisible();
+}
+
+function scoreInputs(page: Page) {
+  return page.locator(".score-input");
+}
+
+function totalOutput(page: Page) {
+  return page.locator("[data-total-output]");
+}
+
+function submitButton(page: Page) {
+  return page.getByRole("button", { name: "入力完了" });
+}
+
+test.describe("点数入力画面", () => {
+  test("点数を入力すると合計がリアルタイムで更新される", async ({ page }) => {
+    await createGameAndGoToScoreInput(page);
+
+    await scoreInputs(page).nth(0).fill("250");
+    await expect(totalOutput(page)).toHaveText("25000");
+
+    await scoreInputs(page).nth(1).fill("300");
+    await expect(totalOutput(page)).toHaveText("55000");
+  });
+
+  test("3人分入力すると4人目が自動補完される", async ({ page }) => {
+    await createGameAndGoToScoreInput(page);
+
+    await scoreInputs(page).nth(0).fill("250");
+    await scoreInputs(page).nth(1).fill("300");
+    await scoreInputs(page).nth(2).fill("200");
+
+    await expect(scoreInputs(page).nth(3)).toHaveValue("250");
+    await expect(totalOutput(page)).toHaveText("100000");
+  });
+
+  test("合計が10万点でないと送信ボタンが無効のまま", async ({ page }) => {
+    await createGameAndGoToScoreInput(page);
+
+    await scoreInputs(page).nth(0).fill("250");
+    await scoreInputs(page).nth(1).fill("300");
+    await scoreInputs(page).nth(2).fill("200");
+    await scoreInputs(page).nth(3).fill("200");
+
+    await expect(submitButton(page)).toBeDisabled();
+  });
+
+  test("範囲外の値で送信ボタンが無効のまま", async ({ page }) => {
+    await createGameAndGoToScoreInput(page);
+
+    await scoreInputs(page).nth(0).fill("1001");
+    await scoreInputs(page).nth(1).fill("0");
+    await scoreInputs(page).nth(2).fill("0");
+
+    await expect(submitButton(page)).toBeDisabled();
+  });
+
+  test("全項目が正しく入力されると送信ボタンが有効になる", async ({ page }) => {
+    await createGameAndGoToScoreInput(page);
+
+    await scoreInputs(page).nth(0).fill("250");
+    await scoreInputs(page).nth(1).fill("300");
+    await scoreInputs(page).nth(2).fill("200");
+
+    await expect(scoreInputs(page).nth(3)).toHaveValue("250");
+    await expect(submitButton(page)).toBeEnabled();
+  });
+
+  test("自動補完された値を手動で書き換えると再計算される", async ({ page }) => {
+    await createGameAndGoToScoreInput(page);
+
+    await scoreInputs(page).nth(0).fill("250");
+    await scoreInputs(page).nth(1).fill("300");
+    await scoreInputs(page).nth(2).fill("200");
+    await expect(scoreInputs(page).nth(3)).toHaveValue("250");
+
+    await scoreInputs(page).nth(3).fill("100");
+    await expect(totalOutput(page)).toHaveText("85000");
+    await expect(submitButton(page)).toBeDisabled();
+  });
+
+  test("正しい点数で送信するとスコア一覧に遷移する", async ({ page }) => {
+    await createGameAndGoToScoreInput(page);
+
+    await scoreInputs(page).nth(0).fill("250");
+    await scoreInputs(page).nth(1).fill("300");
+    await scoreInputs(page).nth(2).fill("200");
+    await expect(scoreInputs(page).nth(3)).toHaveValue("250");
+
+    await submitButton(page).click();
+    await expect(page.getByText("1回戦")).toBeVisible();
+  });
+});

--- a/e2e/score_input.spec.ts
+++ b/e2e/score_input.spec.ts
@@ -17,7 +17,7 @@ function scoreInputs(page: Page) {
 }
 
 function totalOutput(page: Page) {
-  return page.locator("[data-total-output]");
+  return page.locator("[data-score-input-target='totalOutput']");
 }
 
 function submitButton(page: Page) {


### PR DESCRIPTION
## Summary

- `rounds/new.html.erb` 末尾の `<script>` タグ（約90行）を `score_input_controller.js` に切り出し
- ビューを `data-controller` / `data-action` / `data-score-input-target` 属性に置き換え
- Playwright E2E テスト（7ケース）を追加し、リファクタ前後で振る舞いが同一であることを機械的に保証

## 変更内容

- `app/javascript/controllers/score_input_controller.js` を新規作成
- `app/views/rounds/new.html.erb` からインラインJS を削除し、Stimulus 属性に置き換え
- `e2e/score_input.spec.ts` を追加（合計自動計算 / 自動補完 / バリデーション / 送信ボタン制御 / 送信遷移）

## Test plan

- [x] 点数を入力すると合計がリアルタイムで更新される
- [x] 3人分入力すると4人目が自動補完される
- [x] 合計が10万点でないと送信ボタンが無効のまま
- [x] 範囲外の値で送信ボタンが無効のまま
- [x] 全項目が正しく入力されると送信ボタンが有効になる
- [x] 自動補完された値を手動で書き換えると再計算される
- [x] 正しい点数で送信するとスコア一覧に遷移する
- [x] RSpec 66 examples, 0 failures
- [x] Playwright 8 passed（既存1 + 新規7）

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)