### PR TITLE
feat: Playwright E2E テストを CI に統合する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,75 @@ jobs:
 
       - name: RSpec
         run: bundle exec rspec
+
+  e2e:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: mahjong_score_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      RAILS_ENV: test
+      DATABASE_HOST: localhost
+      DATABASE_USERNAME: postgres
+      DATABASE_PASSWORD: password
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3.10"
+          bundler-cache: true
+
+      - name: DB setup
+        run: bin/rails db:create db:schema:load
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: Start Rails server
+        run: bin/rails server -b 0.0.0.0 -p 3000 &
+
+      - name: Wait for server
+        run: |
+          for i in $(seq 1 30); do
+            curl -s http://localhost:3000 > /dev/null && exit 0
+            sleep 1
+          done
+          echo "Server failed to start" && exit 1
+
+      - name: Playwright E2E
+        run: npx playwright test
+        env:
+          BASE_URL: http://localhost:3000
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            test-results/
+            playwright-report/
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -167,6 +167,16 @@ export default class extends Controller {
 npx @redocly/cli lint docs/openapi.yaml
 ```
 
+## CI（GitHub Actions）
+
+`main` ブランチへの push / PR で以下が自動実行されます：
+
+- **RSpec**: モデル・リクエストスペック
+- **Playwright E2E**: ブラウザでのユーザー操作テスト
+
+E2E テストが失敗した場合、スクリーンショットと動画が Artifacts として保存されます。
+GitHub の Actions タブ → 該当ワークフロー → `playwright-report` から確認できます。
+
 ## ディレクトリ構成（主要部分）
 
 ```

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,8 @@ export default defineConfig({
   testDir: "./e2e",
   use: {
     baseURL: process.env.BASE_URL || "http://localhost:3000",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
   },
   projects: [
     {


### PR DESCRIPTION
## Summary

- GitHub Actions に Playwright E2E ジョブを追加し、PR ごとに自動実行されるようにした
- 失敗時にスクリーンショット・動画が Artifacts として保存されるようにした
- README に CI セクションを追記した

## 変更内容

- `.github/workflows/ci.yml`: `e2e` ジョブを追加（既存の `test` ジョブは変更なし）
- `playwright.config.ts`: 失敗時のスクショ・動画保存設定を追加
- `README.md`: CI（GitHub Actions）セクションを追記

## Test plan

- [x] ローカルで Playwright E2E テストが全パス（8テスト）
- [x] ローカルで RSpec テストが全パス（66テスト）
- [x] PR 作成後、GitHub Actions で Playwright が自動実行される
- [ ] テスト失敗時にスクショ・動画が Artifacts として残る
- [ ] 既存の RSpec も引き続き CI で実行される

closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)