### PR TITLE
デフォルト値の重複テストを削除する

### DIFF
--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -44,17 +44,6 @@ RSpec.describe "Games", type: :request do
         game = Game.last
         expect(response).to redirect_to(game_path(game))
       end
-
-      it "デフォルトのルール設定で Game が作成される" do
-        post games_path, params: { players: players }
-        game = Game.last
-        expect(game.mochi_ten).to eq 25000
-        expect(game.kaeshi_ten).to eq 30000
-        expect(game.rank_1_bonus).to eq 50
-        expect(game.rank_2_bonus).to eq 10
-        expect(game.rank_3_bonus).to eq(-10)
-        expect(game.rank_4_bonus).to eq(-30)
-      end
     end
 
     context "カスタムルールが指定された場合" do


### PR DESCRIPTION
## 概要
ゲームのデフォルト値6項目の検証が2箇所で二重になっていたため、リクエスト層側を削除してモデル層に一本化する。

## 変更内容
- `spec/requests/games_spec.rb` の「デフォルトのルール設定で Game が作成される」を削除
  - デフォルト値の検証は `spec/models/game_spec.rb:5-13`「デフォルト値」が本来の持ち場
  - 「game パラメータ無しでも作成できる」挙動は「Game が1件作成される」でカバー済み

## テスト
- `rspec`: 66 → 65 examples, 0 failures（green 維持）

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)