### PR TITLE
feat: LIFF版の点数入力画面とスコア一覧を追加する

### DIFF
--- a/frontend/app/games/[id]/page.test.tsx
+++ b/frontend/app/games/[id]/page.test.tsx
@@ -33,12 +33,39 @@ const game = {
   created_at: "2026-07-01T10:00:00Z",
 };
 
-describe("GameDetailPage (ゲーム詳細)", () => {
+// 2局分入力済みのゲーム（合計: 東75.0 / 南60.0 / 西-45.0 / 北-90.0）
+const gameWithRounds = {
+  ...game,
+  rounds: [
+    {
+      id: 1,
+      round_number: 1,
+      scores: [
+        { player_id: 1, ranking_score: 62.0, rank: 1 },
+        { player_id: 2, ranking_score: 10.0, rank: 2 },
+        { player_id: 3, ranking_score: -20.0, rank: 3 },
+        { player_id: 4, ranking_score: -52.0, rank: 4 },
+      ],
+    },
+    {
+      id: 2,
+      round_number: 2,
+      scores: [
+        { player_id: 1, ranking_score: 13.0, rank: 2 },
+        { player_id: 2, ranking_score: 50.0, rank: 1 },
+        { player_id: 3, ranking_score: -25.0, rank: 3 },
+        { player_id: 4, ranking_score: -38.0, rank: 4 },
+      ],
+    },
+  ],
+};
+
+describe("GameDetailPage (スコア一覧)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("プレイヤー名とルールを表示する", async () => {
+  it("プレイヤー名を表示する", async () => {
     mockedGetGame.mockResolvedValue(game);
 
     render(<GameDetailPage />);
@@ -47,9 +74,37 @@ describe("GameDetailPage (ゲーム詳細)", () => {
     expect(screen.getByText("南")).toBeInTheDocument();
     expect(screen.getByText("西")).toBeInTheDocument();
     expect(screen.getByText("北")).toBeInTheDocument();
-    expect(screen.getByText(/25000/)).toBeInTheDocument();
-    expect(screen.getByText(/30000/)).toBeInTheDocument();
     expect(mockedGetGame).toHaveBeenCalledWith(1);
+  });
+
+  it("入力済みの局の順位点と合計を表示する", async () => {
+    mockedGetGame.mockResolvedValue(gameWithRounds);
+
+    render(<GameDetailPage />);
+
+    // 各局の順位点
+    expect(await screen.findByText("62.0")).toBeInTheDocument();
+    expect(screen.getByText("-52.0")).toBeInTheDocument();
+    expect(screen.getByText("50.0")).toBeInTheDocument();
+    // プレイヤーごとの合計
+    expect(screen.getByText("75.0")).toBeInTheDocument();
+    expect(screen.getByText("-90.0")).toBeInTheDocument();
+  });
+
+  it("局番号から点数入力画面へのリンクを表示する（12局分）", async () => {
+    mockedGetGame.mockResolvedValue(gameWithRounds);
+
+    render(<GameDetailPage />);
+
+    expect(await screen.findByRole("link", { name: "1" })).toHaveAttribute(
+      "href",
+      "/games/1/rounds/new?round_number=1"
+    );
+    // 未入力の局にもリンクがある
+    expect(screen.getByRole("link", { name: "12" })).toHaveAttribute(
+      "href",
+      "/games/1/rounds/new?round_number=12"
+    );
   });
 
   it("一覧へ戻るリンクを表示する", async () => {

--- a/frontend/app/games/[id]/page.tsx
+++ b/frontend/app/games/[id]/page.tsx
@@ -5,9 +5,12 @@ import Link from "next/link";
 import { useParams } from "next/navigation";
 import { ApiError, getGame, type GameDetail } from "../../lib/api";
 
+// MPA 版 games#show と同じく 12 局分の枠を表示する
+const ROUND_COUNT = 12;
+
 type Status = "loading" | "ready" | "error";
 
-// ゲーム詳細（プレイヤー・ルールの確認）。点数入力機能は #158 で追加する。
+// スコア一覧（MPA 版 games#show の移植）。局番号から点数入力画面へ遷移する。
 export default function GameDetailPage() {
   const params = useParams<{ id: string }>();
   const [status, setStatus] = useState<Status>("loading");
@@ -51,28 +54,65 @@ export default function GameDetailPage() {
     );
   }
 
+  const findRankingScore = (roundNumber: number, playerId: number) => {
+    const round = game.rounds.find((r) => r.round_number === roundNumber);
+    const score = round?.scores.find((s) => s.player_id === playerId);
+    return score?.ranking_score ?? null;
+  };
+
+  const totalRankingScore = (playerId: number) =>
+    game.rounds.reduce((sum, round) => {
+      const score = round.scores.find((s) => s.player_id === playerId);
+      return sum + (score?.ranking_score ?? 0);
+    }, 0);
+
   return (
     <main style={{ padding: "1.5rem" }}>
-      <h1>ゲーム詳細</h1>
+      <h1>スコア一覧</h1>
 
-      <h2>メンバー</h2>
-      <ul>
-        {game.players.map((player) => (
-          <li key={player.id}>{player.name}</li>
-        ))}
-      </ul>
+      <p>{new Date(game.created_at).toLocaleDateString("ja-JP")}</p>
 
-      <h2>ルール</h2>
-      <ul>
-        <li>持ち点: {game.mochi_ten}</li>
-        <li>返し点: {game.kaeshi_ten}</li>
-        <li>
-          順位点: {game.rank_1_bonus} / {game.rank_2_bonus} /{" "}
-          {game.rank_3_bonus} / {game.rank_4_bonus}
-        </li>
-      </ul>
-
-      <p>点数入力機能は準備中です。</p>
+      <table>
+        <thead>
+          <tr>
+            <th></th>
+            {game.players.map((player) => (
+              <th key={player.id}>{player.name}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {Array.from({ length: ROUND_COUNT }, (_, i) => i + 1).map(
+            (roundNumber) => (
+              <tr key={roundNumber}>
+                <td>
+                  <Link
+                    href={`/games/${game.id}/rounds/new?round_number=${roundNumber}`}
+                  >
+                    {roundNumber}
+                  </Link>
+                </td>
+                {game.players.map((player) => {
+                  const score = findRankingScore(roundNumber, player.id);
+                  return (
+                    <td key={player.id}>
+                      {score != null ? score.toFixed(1) : ""}
+                    </td>
+                  );
+                })}
+              </tr>
+            )
+          )}
+        </tbody>
+        <tfoot>
+          <tr>
+            <td>合計</td>
+            {game.players.map((player) => (
+              <td key={player.id}>{totalRankingScore(player.id).toFixed(1)}</td>
+            ))}
+          </tr>
+        </tfoot>
+      </table>
 
       <p>
         <Link href="/">← 一覧に戻る</Link>

--- a/frontend/app/games/[id]/rounds/new/page.test.tsx
+++ b/frontend/app/games/[id]/rounds/new/page.test.tsx
@@ -1,0 +1,203 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError, createRound, getGame } from "../../../../lib/api";
+import NewRoundPage from "./page";
+
+const { pushMock, searchParamsHolder } = vi.hoisted(() => ({
+  pushMock: vi.fn(),
+  searchParamsHolder: { query: "" },
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ id: "1" }),
+  useRouter: () => ({ push: pushMock }),
+  useSearchParams: () => new URLSearchParams(searchParamsHolder.query),
+}));
+
+// getGame / createRound だけモックし、ApiError などは実物をそのまま使う
+vi.mock("../../../../lib/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../../lib/api")>()),
+  getGame: vi.fn(),
+  createRound: vi.fn(),
+}));
+
+const mockedGetGame = vi.mocked(getGame);
+const mockedCreateRound = vi.mocked(createRound);
+
+// 1・2回戦が入力済みのゲーム（次は3回戦）
+const game = {
+  id: 1,
+  mochi_ten: 25000,
+  kaeshi_ten: 30000,
+  rank_1_bonus: 50,
+  rank_2_bonus: 10,
+  rank_3_bonus: -10,
+  rank_4_bonus: -30,
+  players: [
+    { id: 1, name: "東" },
+    { id: 2, name: "南" },
+    { id: 3, name: "西" },
+    { id: 4, name: "北" },
+  ],
+  rounds: [
+    { id: 1, round_number: 1, scores: [] },
+    { id: 2, round_number: 2, scores: [] },
+  ],
+  created_at: "2026-07-01T10:00:00Z",
+};
+
+const createdRound = {
+  id: 3,
+  round_number: 3,
+  scores: [
+    { player_id: 1, ranking_score: 62.0, rank: 1 },
+    { player_id: 2, ranking_score: 10.0, rank: 2 },
+    { player_id: 3, ranking_score: -20.0, rank: 3 },
+    { player_id: 4, ranking_score: -52.0, rank: 4 },
+  ],
+};
+
+// 東・南・西の3人分を入力する（北は自動計算対象）
+async function fillThreeScores(values: [string, string, string]) {
+  const user = userEvent.setup();
+  await user.type(screen.getByLabelText("東の点数"), values[0]);
+  await user.type(screen.getByLabelText("南の点数"), values[1]);
+  await user.type(screen.getByLabelText("西の点数"), values[2]);
+  return user;
+}
+
+describe("NewRoundPage (点数入力フォーム)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    searchParamsHolder.query = "";
+    mockedGetGame.mockResolvedValue(game);
+  });
+
+  it("プレイヤー4人分の入力欄と回戦番号を表示する", async () => {
+    render(<NewRoundPage />);
+
+    expect(await screen.findByLabelText("東の点数")).toBeInTheDocument();
+    expect(screen.getByLabelText("南の点数")).toBeInTheDocument();
+    expect(screen.getByLabelText("西の点数")).toBeInTheDocument();
+    expect(screen.getByLabelText("北の点数")).toBeInTheDocument();
+    // 未指定なら次の回戦（入力済み最大 2 + 1）
+    expect(screen.getByText("3回戦")).toBeInTheDocument();
+    expect(mockedGetGame).toHaveBeenCalledWith(1);
+  });
+
+  it("入力に応じて合計（点数換算）を表示する", async () => {
+    render(<NewRoundPage />);
+    await screen.findByLabelText("東の点数");
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText("東の点数"), "350");
+
+    // 350（百点棒単位）→ 35000点
+    expect(screen.getByText("35000")).toBeInTheDocument();
+  });
+
+  it("3人入力すると残り1人が自動計算される", async () => {
+    render(<NewRoundPage />);
+    await screen.findByLabelText("東の点数");
+
+    await fillThreeScores(["350", "300", "250"]);
+
+    expect(screen.getByLabelText("北の点数")).toHaveValue("100");
+    expect(screen.getByText("100000")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "入力完了" })).toBeEnabled();
+  });
+
+  it("自動計算された欄を手入力すると自動計算の対象から外れる", async () => {
+    render(<NewRoundPage />);
+    await screen.findByLabelText("東の点数");
+
+    const user = await fillThreeScores(["350", "300", "250"]);
+    // 自動計算された北を手で書き換える
+    await user.clear(screen.getByLabelText("北の点数"));
+    await user.type(screen.getByLabelText("北の点数"), "90");
+    // 他の欄を変更しても北は再計算されない
+    await user.clear(screen.getByLabelText("東の点数"));
+    await user.type(screen.getByLabelText("東の点数"), "340");
+
+    expect(screen.getByLabelText("北の点数")).toHaveValue("90");
+  });
+
+  it("合計が100,000点にならない場合は送信できずメッセージを表示する", async () => {
+    render(<NewRoundPage />);
+    await screen.findByLabelText("東の点数");
+
+    const user = await fillThreeScores(["350", "300", "250"]);
+    await user.clear(screen.getByLabelText("北の点数"));
+    await user.type(screen.getByLabelText("北の点数"), "90");
+
+    expect(screen.getByRole("button", { name: "入力完了" })).toBeDisabled();
+    expect(
+      screen.getByText("入力内容を確認してください")
+    ).toBeInTheDocument();
+  });
+
+  it("範囲外の値（±1000超）では送信できない", async () => {
+    render(<NewRoundPage />);
+    await screen.findByLabelText("東の点数");
+
+    await fillThreeScores(["1001", "300", "250"]);
+
+    expect(screen.getByRole("button", { name: "入力完了" })).toBeDisabled();
+  });
+
+  it("有効な入力で送信すると createRound を呼び、スコア一覧へ戻る", async () => {
+    mockedCreateRound.mockResolvedValue(createdRound);
+    render(<NewRoundPage />);
+    await screen.findByLabelText("東の点数");
+
+    const user = await fillThreeScores(["350", "300", "250"]);
+    await user.click(screen.getByRole("button", { name: "入力完了" }));
+
+    expect(mockedCreateRound).toHaveBeenCalledWith(1, {
+      round_number: 3,
+      scores: [
+        { player_id: 1, point: 350 },
+        { player_id: 2, point: 300 },
+        { player_id: 3, point: 250 },
+        { player_id: 4, point: 100 },
+      ],
+    });
+    await vi.waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith("/games/1");
+    });
+  });
+
+  it("round_number 指定時はその回戦として上書き保存する", async () => {
+    searchParamsHolder.query = "round_number=2";
+    mockedCreateRound.mockResolvedValue({ ...createdRound, round_number: 2 });
+    render(<NewRoundPage />);
+    await screen.findByLabelText("東の点数");
+
+    expect(screen.getByText("2回戦")).toBeInTheDocument();
+
+    const user = await fillThreeScores(["350", "300", "250"]);
+    await user.click(screen.getByRole("button", { name: "入力完了" }));
+
+    expect(mockedCreateRound).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ round_number: 2 })
+    );
+  });
+
+  it("API エラー時にメッセージを表示する", async () => {
+    mockedCreateRound.mockRejectedValue(
+      new ApiError(["点数の合計が 1000 になりません"])
+    );
+    render(<NewRoundPage />);
+    await screen.findByLabelText("東の点数");
+
+    const user = await fillThreeScores(["350", "300", "250"]);
+    await user.click(screen.getByRole("button", { name: "入力完了" }));
+
+    expect(
+      await screen.findByText(/点数の合計が 1000 になりません/)
+    ).toBeInTheDocument();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/games/[id]/rounds/new/page.tsx
+++ b/frontend/app/games/[id]/rounds/new/page.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useEffect, useState, type FormEvent } from "react";
+import Link from "next/link";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import {
+  ApiError,
+  createRound,
+  getGame,
+  type GameDetail,
+} from "../../../../lib/api";
+import {
+  MAX_UNIT,
+  MIN_UNIT,
+  TARGET_UNITS,
+  UNIT_SCALE,
+  applyAutoCalc,
+  parseValue,
+  sumUnits,
+  type ScoreFlag,
+} from "../../../../lib/score-input";
+
+type Status = "loading" | "ready" | "error";
+
+// 点数入力フォーム（MPA 版 rounds#new の移植）。
+// round_number 指定時は既存局の上書き編集になる。
+export default function NewRoundPage() {
+  const params = useParams<{ id: string }>();
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const gameId = Number(params.id);
+
+  const [status, setStatus] = useState<Status>("loading");
+  const [game, setGame] = useState<GameDetail | null>(null);
+  const [values, setValues] = useState<string[]>([]);
+  const [flags, setFlags] = useState<ScoreFlag[]>([]);
+  const [hasInteracted, setHasInteracted] = useState(false);
+  const [errors, setErrors] = useState<string[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const loaded = await getGame(gameId);
+        setGame(loaded);
+        setValues(Array(loaded.players.length).fill(""));
+        setFlags(Array(loaded.players.length).fill(null));
+        setStatus("ready");
+      } catch (error) {
+        setErrors(
+          error instanceof ApiError
+            ? error.messages
+            : ["ゲームの取得に失敗しました。時間をおいて再読み込みしてください"]
+        );
+        setStatus("error");
+      }
+    };
+
+    load();
+  }, [gameId]);
+
+  const requestedRoundNumber = parseValue(
+    searchParams.get("round_number") ?? ""
+  );
+  const nextRoundNumber =
+    game == null
+      ? null
+      : requestedRoundNumber ??
+        Math.max(0, ...game.rounds.map((r) => r.round_number)) + 1;
+
+  const handleChange = (index: number, raw: string) => {
+    setHasInteracted(true);
+    const inputValues = values.map((v, i) => (i === index ? raw : v));
+    const inputFlags = flags.map<ScoreFlag>((f, i) =>
+      i === index ? "manual" : f
+    );
+    const next = applyAutoCalc(inputValues, inputFlags);
+    setValues(next.values);
+    setFlags(next.flags);
+  };
+
+  const units = values.map(parseValue);
+  const totalUnits = sumUnits(values);
+  const allFilled = units.length > 0 && units.every((u) => u != null);
+  const inRange = units.every(
+    (u) => u == null || (u >= MIN_UNIT && u <= MAX_UNIT)
+  );
+  const isValid = allFilled && inRange && totalUnits === TARGET_UNITS;
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!isValid || submitting || game == null || nextRoundNumber == null) {
+      return;
+    }
+
+    setSubmitting(true);
+    setErrors([]);
+    try {
+      await createRound(gameId, {
+        round_number: nextRoundNumber,
+        scores: game.players.map((player, i) => ({
+          player_id: player.id,
+          point: units[i] as number,
+        })),
+      });
+      router.push(`/games/${gameId}`);
+    } catch (error) {
+      if (error instanceof ApiError) {
+        setErrors(error.messages);
+      } else {
+        setErrors(["点数の保存に失敗しました。時間をおいて再度お試しください"]);
+      }
+      setSubmitting(false);
+    }
+  };
+
+  if (status === "loading") {
+    return (
+      <main style={{ padding: "2rem", textAlign: "center" }}>
+        <p>読み込み中…</p>
+      </main>
+    );
+  }
+
+  if (status === "error" || game === null) {
+    return (
+      <main style={{ padding: "2rem", textAlign: "center" }}>
+        <p role="alert">{errors.join("、")}</p>
+        <p>
+          <Link href="/">← 一覧に戻る</Link>
+        </p>
+      </main>
+    );
+  }
+
+  return (
+    <main style={{ padding: "1.5rem" }}>
+      <h1>点数入力</h1>
+      <h2>{nextRoundNumber}回戦</h2>
+
+      {errors.length > 0 && (
+        <ul role="alert" style={{ color: "red" }}>
+          {errors.map((message) => (
+            <li key={message}>{message}</li>
+          ))}
+        </ul>
+      )}
+
+      <form onSubmit={handleSubmit}>
+        {game.players.map((player, i) => (
+          <div key={player.id}>
+            <label htmlFor={`score_${player.id}`}>{player.name}の点数</label>
+            <input
+              type="text"
+              id={`score_${player.id}`}
+              inputMode="numeric"
+              pattern="-?[0-9]*"
+              autoComplete="off"
+              maxLength={5}
+              value={values[i] ?? ""}
+              onChange={(event) => handleChange(i, event.target.value)}
+            />
+            <span>00点</span>
+          </div>
+        ))}
+
+        <p>
+          合計 <span>{totalUnits * UNIT_SCALE}</span> 点
+        </p>
+
+        <button type="submit" disabled={!isValid || submitting}>
+          入力完了
+        </button>
+        {hasInteracted && !isValid && <p>入力内容を確認してください</p>}
+      </form>
+
+      <p>
+        <Link href={`/games/${gameId}`}>← スコア一覧に戻る</Link>
+      </p>
+    </main>
+  );
+}

--- a/frontend/app/games/new/page.test.tsx
+++ b/frontend/app/games/new/page.test.tsx
@@ -58,7 +58,7 @@ describe("NewGamePage (ゲーム作成フォーム)", () => {
     expect(screen.getByLabelText("4位")).toHaveValue(-30);
   });
 
-  it("入力した値で createGame を呼び、成功したら一覧へ戻る", async () => {
+  it("入力した値で createGame を呼び、成功したらスコア一覧へ遷移する", async () => {
     mockedCreateGame.mockResolvedValue(createdGame);
     render(<NewGamePage />);
 
@@ -75,7 +75,8 @@ describe("NewGamePage (ゲーム作成フォーム)", () => {
       players: ["東", "南", "西", "北"],
     });
     await vi.waitFor(() => {
-      expect(pushMock).toHaveBeenCalledWith("/");
+      // MPA 版と同じく、作成したゲームのスコア一覧へ遷移する
+      expect(pushMock).toHaveBeenCalledWith("/games/10");
     });
   });
 

--- a/frontend/app/games/new/page.tsx
+++ b/frontend/app/games/new/page.tsx
@@ -53,8 +53,9 @@ export default function NewGamePage() {
     setSubmitting(true);
     setErrors([]);
     try {
-      await createGame({ ...rules, players });
-      router.push("/");
+      const created = await createGame({ ...rules, players });
+      // MPA 版と同じく、作成したゲームのスコア一覧へ遷移する
+      router.push(`/games/${created.id}`);
     } catch (error) {
       if (error instanceof ApiError) {
         setErrors(error.messages);

--- a/frontend/app/lib/api.test.ts
+++ b/frontend/app/lib/api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ApiError, createGame, getGame, getGames } from "./api";
+import { ApiError, createGame, createRound, getGame, getGames } from "./api";
 
 const gameSummary = {
   id: 1,
@@ -126,6 +126,53 @@ describe("api クライアント", () => {
 
       await expect(createGame(params)).rejects.toMatchObject({
         messages: ["順位点の合計が正しくありません（現在: 0、期待値: 20）"],
+      });
+    });
+  });
+
+  describe("createRound", () => {
+    // point は百点棒単位（350 = 35,000点）
+    const params = {
+      round_number: 3,
+      scores: [
+        { player_id: 1, point: 350 },
+        { player_id: 2, point: 300 },
+        { player_id: 3, point: 250 },
+        { player_id: 4, point: 100 },
+      ],
+    };
+
+    const roundDetail = {
+      id: 5,
+      round_number: 3,
+      scores: [
+        { player_id: 1, ranking_score: 62.0, rank: 1 },
+        { player_id: 2, ranking_score: 10.0, rank: 2 },
+        { player_id: 3, ranking_score: -20.0, rank: 3 },
+        { player_id: 4, ranking_score: -52.0, rank: 4 },
+      ],
+    };
+
+    it("点数を JSON で POST し、作成された局を返す", async () => {
+      mockedFetch().mockResolvedValue(jsonResponse(roundDetail, 201));
+
+      const round = await createRound(1, params);
+
+      expect(mockedFetch()).toHaveBeenCalledWith("/api/v1/games/1/rounds", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(params),
+      });
+      expect(round.round_number).toBe(3);
+    });
+
+    it("422 のときはバリデーションメッセージを持つ ApiError を投げる", async () => {
+      mockedFetch().mockResolvedValue(
+        jsonResponse({ errors: ["点数の合計が 1000 になりません"] }, 422)
+      );
+
+      await expect(createRound(1, params)).rejects.toMatchObject({
+        messages: ["点数の合計が 1000 になりません"],
       });
     });
   });

--- a/frontend/app/lib/api.ts
+++ b/frontend/app/lib/api.ts
@@ -40,6 +40,12 @@ export type GameDetail = {
   created_at: string;
 };
 
+export type CreateRoundParams = {
+  round_number: number;
+  // point は百点棒単位（350 = 35,000点）
+  scores: { player_id: number; point: number }[];
+};
+
 export type CreateGameParams = {
   mochi_ten: number;
   kaeshi_ten: number;
@@ -105,6 +111,17 @@ export async function createGame(
   params: CreateGameParams
 ): Promise<GameDetail> {
   return request<GameDetail>("/api/v1/games", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(params),
+  });
+}
+
+export async function createRound(
+  gameId: number,
+  params: CreateRoundParams
+): Promise<Round> {
+  return request<Round>(`/api/v1/games/${gameId}/rounds`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(params),

--- a/frontend/app/lib/score-input.ts
+++ b/frontend/app/lib/score-input.ts
@@ -1,0 +1,70 @@
+// 点数入力の計算ロジック（MPA 版 score_input_controller.js の移植）。
+// 点数は百点棒単位（350 = 35,000点）で扱い、合計は 1000（= 100,000点）固定。
+
+export const TARGET_UNITS = 1000;
+export const UNIT_SCALE = 100;
+export const MIN_UNIT = -1000;
+export const MAX_UNIT = 1000;
+
+// manual: 手入力された欄 / auto: 自動計算で埋めた欄
+export type ScoreFlag = "manual" | "auto" | null;
+
+export function parseValue(value: string): number | null {
+  const trimmed = value.trim();
+  if (trimmed === "") return null;
+  const number = Number(trimmed);
+  if (!Number.isFinite(number)) return null;
+  return Math.trunc(number);
+}
+
+export function sumUnits(
+  values: string[],
+  skipIndex: number | null = null
+): number {
+  return values.reduce((sum, value, i) => {
+    if (i === skipIndex) return sum;
+    const parsed = parseValue(value);
+    return parsed == null ? sum : sum + parsed;
+  }, 0);
+}
+
+function countFilled(values: string[], skipIndex: number | null = null): number {
+  return values.filter(
+    (value, i) => i !== skipIndex && parseValue(value) != null
+  ).length;
+}
+
+// 3人分入力されたら残り1人を自動計算する（手入力済みの欄には触らない）
+export function applyAutoCalc(
+  values: string[],
+  flags: ScoreFlag[]
+): { values: string[]; flags: ScoreFlag[] } {
+  const nextValues = [...values];
+  const nextFlags = [...flags];
+  const autoIndex = nextFlags.indexOf("auto");
+  let targetIndex: number | null = null;
+
+  if (
+    autoIndex >= 0 &&
+    countFilled(nextValues, autoIndex) === values.length - 1
+  ) {
+    targetIndex = autoIndex;
+  } else if (autoIndex < 0 && countFilled(nextValues) === values.length - 1) {
+    const emptyIndex = nextValues.findIndex((v) => parseValue(v) == null);
+    if (emptyIndex >= 0 && nextFlags[emptyIndex] !== "manual") {
+      targetIndex = emptyIndex;
+    }
+  }
+
+  if (targetIndex != null) {
+    nextValues[targetIndex] = String(
+      TARGET_UNITS - sumUnits(nextValues, targetIndex)
+    );
+    nextFlags[targetIndex] = "auto";
+  } else if (autoIndex >= 0) {
+    nextValues[autoIndex] = "";
+    nextFlags[autoIndex] = null;
+  }
+
+  return { values: nextValues, flags: nextFlags };
+}


### PR DESCRIPTION
## 概要

- Issue #158 の対応
- MPA 版の点数入力フローを LIFF 版（Next.js）に移植する

## 現状

- LIFF 版はゲーム詳細でメンバー・ルールを表示するのみで、点数入力ができない（#157 時点のつなぎ実装）

## 目的

- メインのユースケースである点数入力を LIFF 版で完結できるようにする

## 変更内容

- **点数入力画面** `/games/[id]/rounds/new` を新規追加
  - 百点棒単位・`inputmode="numeric"` の入力欄 × 4人分
  - 3人入力すると残り1人を自動計算（MPA 版 Stimulus `score_input_controller.js` の移植）
  - 合計 100,000 点のリアルタイムバリデーション（不一致・範囲外・未入力は送信不可）
  - `round_number` クエリ指定で既存局の上書き編集
- **スコア一覧** `/games/[id]` を MPA 版 games#show 相当のテーブルに置き換え
  - 12局分の順位点・プレイヤーごとの合計を表示
  - 局番号タップで該当局の入力画面へ遷移
- **API クライアント** `createRound()` を追加（既存の `POST /api/v1/games/:id/rounds` を使用、Rails 側の変更なし）
- 点数計算ロジックは `app/lib/score-input.ts` に分離

## やらないこと（Issue 記載どおり）

- 局の削除機能 / 独自テンキー・符号切替ボタン / 配給原点の可変対応

## テスト

- Vitest + RTL で13件追加（全36件パス）: 自動計算・バリデーション・上書き編集・API エラー表示・一覧表示
- 型チェック・ESLint・本番ビルド確認済み
- ローカルで Rails + Next.js + Chrome による実操作確認済み（入力→自動計算→送信→一覧反映→上書き編集）
- LINE アプリ実機でも動作確認済み（ngrok 経由）

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)