### PR TITLE
feat: LIFF版スコア一覧に「URLを共有する」ボタンを追加する

### DIFF
--- a/frontend/app/games/[id]/page.test.tsx
+++ b/frontend/app/games/[id]/page.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiError, getGame } from "../../lib/api";
 import GameDetailPage from "./page";
 
@@ -125,5 +125,98 @@ describe("GameDetailPage (スコア一覧)", () => {
     expect(
       await screen.findByText(/ゲームが見つかりません/)
     ).toBeInTheDocument();
+  });
+});
+
+describe("GameDetailPage (URLを共有する)", () => {
+  const shareUrl = "https://liff.line.me/test-liff-id/games/1";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("NEXT_PUBLIC_LIFF_ID", "test-liff-id");
+    mockedGetGame.mockResolvedValue(game);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    // テストごとに navigator へ生やしたモックを片付ける
+    Reflect.deleteProperty(window.navigator, "share");
+    Reflect.deleteProperty(window.navigator, "clipboard");
+  });
+
+  it("「URLを共有する」ボタンを表示する", async () => {
+    render(<GameDetailPage />);
+
+    expect(
+      await screen.findByRole("button", { name: "URLを共有する" })
+    ).toBeInTheDocument();
+  });
+
+  it("navigator.share が使える環境では LIFF リンク付きで共有シートを開く", async () => {
+    const share = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window.navigator, "share", {
+      value: share,
+      configurable: true,
+    });
+
+    render(<GameDetailPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "URLを共有する" })
+    );
+
+    await vi.waitFor(() => {
+      expect(share).toHaveBeenCalledWith({
+        title: "麻雀スコア",
+        url: shareUrl,
+      });
+    });
+  });
+
+  it("navigator.share がない環境ではコピーして「コピーしました！」を2秒表示する", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window.navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+
+    render(<GameDetailPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "URLを共有する" })
+    );
+
+    expect(
+      await screen.findByRole("button", { name: "コピーしました！" })
+    ).toBeInTheDocument();
+    expect(writeText).toHaveBeenCalledWith(shareUrl);
+
+    // 2秒後に元の文言へ戻る
+    await vi.waitFor(
+      () => {
+        expect(
+          screen.getByRole("button", { name: "URLを共有する" })
+        ).toBeInTheDocument();
+      },
+      { timeout: 3000 }
+    );
+  });
+
+  it("共有シートをキャンセルしてもエラーにならない", async () => {
+    const share = vi
+      .fn()
+      .mockRejectedValue(new DOMException("Share canceled", "AbortError"));
+    Object.defineProperty(window.navigator, "share", {
+      value: share,
+      configurable: true,
+    });
+
+    render(<GameDetailPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "URLを共有する" })
+    );
+
+    await vi.waitFor(() => {
+      expect(share).toHaveBeenCalled();
+    });
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 });

--- a/frontend/app/games/[id]/page.tsx
+++ b/frontend/app/games/[id]/page.tsx
@@ -16,6 +16,7 @@ export default function GameDetailPage() {
   const [status, setStatus] = useState<Status>("loading");
   const [game, setGame] = useState<GameDetail | null>(null);
   const [errorMessage, setErrorMessage] = useState("");
+  const [shareLabel, setShareLabel] = useState("URLを共有する");
 
   useEffect(() => {
     const load = async () => {
@@ -66,6 +67,28 @@ export default function GameDetailPage() {
       return sum + (score?.ranking_score ?? 0);
     }, 0);
 
+  // MPA 版 games#show と同挙動: 共有シートが使えなければクリップボードコピーにフォールバック
+  const handleShare = async () => {
+    const url = `https://liff.line.me/${process.env.NEXT_PUBLIC_LIFF_ID}/games/${game.id}`;
+
+    if (navigator.share) {
+      try {
+        await navigator.share({ title: "麻雀スコア", url });
+      } catch {
+        // 共有シートのキャンセルはエラー扱いしない
+      }
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(url);
+      setShareLabel("コピーしました！");
+      setTimeout(() => setShareLabel("URLを共有する"), 2000);
+    } catch {
+      // コピーできない環境では何もしない
+    }
+  };
+
   return (
     <main style={{ padding: "1.5rem" }}>
       <h1>スコア一覧</h1>
@@ -113,6 +136,12 @@ export default function GameDetailPage() {
           </tr>
         </tfoot>
       </table>
+
+      <p>
+        <button type="button" onClick={handleShare}>
+          {shareLabel}
+        </button>
+      </p>
 
       <p>
         <Link href="/">← トップに戻る</Link>


### PR DESCRIPTION
## Summary

- MPA 版 games#show の「URLを共有する」ボタンを LIFF 版スコア一覧（`/games/[id]`）に移植する
- 挙動は MPA 版と同じ 2 段構え: `navigator.share` があれば OS の共有シート、なければクリップボードコピー＋「コピーしました！」を 2 秒表示
- 共有 URL は LIFF ディープリンク `https://liff.line.me/{LIFF_ID}/games/{id}`（受け取った人が LINE でそのまま LIFF 版スコア一覧を開ける）

closes #196

## 補足

- 本番 MPA 版（HTTP）では `navigator.share` がブラウザ仕様で無効のためコピー動作になるが、これは環境差であり実装は同一の 2 段構え。MPA 本番を HTTPS 化すれば同じ体験になる（検討済み・受け入れ）
- 共有シートのキャンセルはエラー扱いしない

## Test plan

- [x] スコア一覧に「URLを共有する」ボタンが表示される（Vitest）
- [x] navigator.share がある環境では LIFF リンク付きで共有シートを開く（Vitest）
- [x] ない環境ではコピーして「コピーしました！」を 2 秒表示（Vitest）
- [x] 共有キャンセルでエラーにならない（Vitest）
- [x] フロントテスト 35 件パス、ESLint・型チェッククリーン
- [x] 実機（LINE アプリ内）で共有シートが開くことを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)