### PR TITLE
feat: LIFF版の見た目をMPA版に揃える

### DIFF
--- a/frontend/app/games/[id]/page.test.tsx
+++ b/frontend/app/games/[id]/page.test.tsx
@@ -91,6 +91,28 @@ describe("GameDetailPage (スコア一覧)", () => {
     expect(screen.getByText("-90.0")).toBeInTheDocument();
   });
 
+  it("日付を MPA 版と同じゼロ埋め形式で表示する", async () => {
+    mockedGetGame.mockResolvedValue(game);
+
+    render(<GameDetailPage />);
+
+    // created_at: 2026-07-01T10:00:00Z（JST 2026/07/01）
+    expect(await screen.findByText("2026/07/01")).toBeInTheDocument();
+  });
+
+  it("マイナスの順位点と合計に negative クラスを付ける（赤字表示）", async () => {
+    mockedGetGame.mockResolvedValue(gameWithRounds);
+
+    render(<GameDetailPage />);
+
+    // 各局のマイナス順位点
+    expect(await screen.findByText("-52.0")).toHaveClass("negative");
+    // マイナスの合計
+    expect(screen.getByText("-90.0")).toHaveClass("negative");
+    // プラスの値には付かない
+    expect(screen.getByText("62.0")).not.toHaveClass("negative");
+  });
+
   it("局番号から点数入力画面へのリンクを表示する（12局分）", async () => {
     mockedGetGame.mockResolvedValue(gameWithRounds);
 

--- a/frontend/app/games/[id]/page.tsx
+++ b/frontend/app/games/[id]/page.tsx
@@ -90,12 +90,21 @@ export default function GameDetailPage() {
   };
 
   return (
-    <main style={{ padding: "1.5rem" }}>
+    <main className="games-show">
       <h1>スコア一覧</h1>
 
-      <p>{new Date(game.created_at).toLocaleDateString("ja-JP")}</p>
+      <div
+        className="game-date"
+        style={{ width: "100%", maxWidth: 600, textAlign: "left" }}
+      >
+        {new Date(game.created_at).toLocaleDateString("ja-JP", {
+          year: "numeric",
+          month: "2-digit",
+          day: "2-digit",
+        })}
+      </div>
 
-      <table>
+      <table className="score-table">
         <thead>
           <tr>
             <th></th>
@@ -118,7 +127,12 @@ export default function GameDetailPage() {
                 {game.players.map((player) => {
                   const score = findRankingScore(roundNumber, player.id);
                   return (
-                    <td key={player.id}>
+                    <td
+                      key={player.id}
+                      className={
+                        score != null && score < 0 ? "negative" : undefined
+                      }
+                    >
                       {score != null ? score.toFixed(1) : ""}
                     </td>
                   );
@@ -130,22 +144,30 @@ export default function GameDetailPage() {
         <tfoot>
           <tr>
             <td>合計</td>
-            {game.players.map((player) => (
-              <td key={player.id}>{totalRankingScore(player.id).toFixed(1)}</td>
-            ))}
+            {game.players.map((player) => {
+              const total = totalRankingScore(player.id);
+              return (
+                <td
+                  key={player.id}
+                  className={total < 0 ? "negative" : undefined}
+                >
+                  {total.toFixed(1)}
+                </td>
+              );
+            })}
           </tr>
         </tfoot>
       </table>
 
-      <p>
-        <button type="button" onClick={handleShare}>
+      <div className="share-section">
+        <button type="button" className="share-button" onClick={handleShare}>
           {shareLabel}
         </button>
-      </p>
+      </div>
 
-      <p>
+      <div className="back-link">
         <Link href="/">← トップに戻る</Link>
-      </p>
+      </div>
     </main>
   );
 }

--- a/frontend/app/games/[id]/rounds/new/page.tsx
+++ b/frontend/app/games/[id]/rounds/new/page.tsx
@@ -134,49 +134,84 @@ export default function NewRoundPage() {
   }
 
   return (
-    <main style={{ padding: "1.5rem" }}>
-      <h1>点数入力</h1>
-      <h2>{nextRoundNumber}回戦</h2>
+    <main className="rounds-new">
+      <div className="rounds-panel">
+        <h1>点数入力</h1>
 
-      {errors.length > 0 && (
-        <ul role="alert" style={{ color: "red" }}>
-          {errors.map((message) => (
-            <li key={message}>{message}</li>
-          ))}
-        </ul>
-      )}
-
-      <form onSubmit={handleSubmit}>
-        {game.players.map((player, i) => (
-          <div key={player.id}>
-            <label htmlFor={`score_${player.id}`}>{player.name}の点数</label>
-            <input
-              type="text"
-              id={`score_${player.id}`}
-              inputMode="numeric"
-              pattern="-?[0-9]*"
-              autoComplete="off"
-              maxLength={5}
-              value={values[i] ?? ""}
-              onChange={(event) => handleChange(i, event.target.value)}
-            />
-            <span>00点</span>
+        {errors.length > 0 && (
+          <div className="form-error" role="alert">
+            {errors.join("、")}
           </div>
-        ))}
+        )}
 
-        <p>
-          合計 <span>{totalUnits * UNIT_SCALE}</span> 点
-        </p>
+        <form onSubmit={handleSubmit} className="rounds-form">
+          <table className="scoreboard">
+            <caption className="scoreboard-caption">
+              {nextRoundNumber}回戦
+            </caption>
+            <thead>
+              <tr>
+                <th>プレイヤー</th>
+                <th>点数</th>
+              </tr>
+            </thead>
+            <tbody>
+              {game.players.map((player, i) => (
+                <tr key={player.id}>
+                  <td className="player-name">{player.name}</td>
+                  <td className="score-cell">
+                    <label htmlFor={`score_${player.id}`} className="sr-only">
+                      {player.name}の点数
+                    </label>
+                    <div className="score-field">
+                      <input
+                        type="text"
+                        id={`score_${player.id}`}
+                        className="score-input"
+                        inputMode="numeric"
+                        pattern="-?[0-9]*"
+                        autoComplete="off"
+                        maxLength={5}
+                        value={values[i] ?? ""}
+                        onChange={(event) => handleChange(i, event.target.value)}
+                      />
+                      <span className="score-unit score-unit--hundreds">
+                        00点
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr className="score-total">
+                <th>合計</th>
+                <td className="score-total-value">
+                  <span>{totalUnits * UNIT_SCALE}</span>
+                  <span className="score-unit">点</span>
+                </td>
+              </tr>
+            </tfoot>
+          </table>
 
-        <button type="submit" disabled={!isValid || submitting}>
-          入力完了
-        </button>
-        {hasInteracted && !isValid && <p>入力内容を確認してください</p>}
-      </form>
+          <div className="form-actions">
+            <button
+              type="submit"
+              className="btn btn-primary rounds-submit"
+              disabled={!isValid || submitting}
+            >
+              入力完了
+            </button>
+            {hasInteracted && !isValid && (
+              <p className="validation-message">入力内容を確認してください</p>
+            )}
+          </div>
+        </form>
+      </div>
 
-      <p>
+      <div className="back-link">
         <Link href={`/games/${gameId}`}>← スコア一覧に戻る</Link>
-      </p>
+      </div>
     </main>
   );
 }

--- a/frontend/app/games/new/page.tsx
+++ b/frontend/app/games/new/page.tsx
@@ -69,53 +69,60 @@ export default function NewGamePage() {
   };
 
   return (
-    <main style={{ padding: "1.5rem" }}>
-      <h1>新規ゲーム作成</h1>
+    <main className="games-new">
+      <h1>メンバー入力</h1>
 
       {errors.length > 0 && (
-        <ul role="alert" style={{ color: "red" }}>
-          {errors.map((message) => (
-            <li key={message}>{message}</li>
-          ))}
-        </ul>
+        <div className="form-error" role="alert">
+          <ul style={{ listStyle: "none" }}>
+            {errors.map((message) => (
+              <li key={message}>{message}</li>
+            ))}
+          </ul>
+        </div>
       )}
 
-      <form onSubmit={handleSubmit}>
-        <h2>メンバー</h2>
-        {players.map((name, i) => (
-          <div key={i}>
-            <label htmlFor={`player_${i + 1}`}>プレイヤー{i + 1}</label>
-            <input
-              type="text"
-              id={`player_${i + 1}`}
-              value={name}
-              required
-              onChange={(event) => updatePlayer(i, event.target.value)}
-            />
-          </div>
-        ))}
+      <form onSubmit={handleSubmit} className="member-form">
+        <div className="player-inputs">
+          {players.map((name, i) => (
+            <div key={i} className="player-input">
+              <label htmlFor={`player_${i + 1}`}>プレイヤー{i + 1}</label>
+              <input
+                type="text"
+                id={`player_${i + 1}`}
+                value={name}
+                required
+                onChange={(event) => updatePlayer(i, event.target.value)}
+              />
+            </div>
+          ))}
+        </div>
 
         <h2>ルール設定</h2>
-        {ruleFields.map(({ key, label }) => (
-          <div key={key}>
-            <label htmlFor={`rule_${key}`}>{label}</label>
-            <input
-              type="number"
-              id={`rule_${key}`}
-              value={rules[key]}
-              onChange={(event) => updateRule(key, event.target.value)}
-            />
-          </div>
-        ))}
+        <div className="rule-inputs">
+          {ruleFields.map(({ key, label }) => (
+            <div key={key} className="rule-input">
+              <label htmlFor={`rule_${key}`}>{label}</label>
+              <input
+                type="number"
+                id={`rule_${key}`}
+                value={rules[key]}
+                onChange={(event) => updateRule(key, event.target.value)}
+              />
+            </div>
+          ))}
+        </div>
 
-        <button type="submit" disabled={submitting}>
-          ゲーム開始
-        </button>
+        <div className="form-actions">
+          <button type="submit" className="btn btn-primary" disabled={submitting}>
+            ゲーム開始
+          </button>
+        </div>
       </form>
 
-      <p>
+      <div className="back-link">
         <Link href="/">← トップに戻る</Link>
-      </p>
+      </div>
     </main>
   );
 }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,15 +1,3 @@
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
 html {
   height: 100%;
 }
@@ -24,8 +12,8 @@ body {
   min-height: 100%;
   display: flex;
   flex-direction: column;
-  color: var(--foreground);
-  background: var(--background);
+  color: #171717;
+  background: #ffffff;
   font-family: Arial, Helvetica, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -37,13 +25,365 @@ body {
   margin: 0;
 }
 
-a {
-  color: inherit;
+/* ここから MPA 版 app/assets/stylesheets/application.css の移植 */
+
+/* Top page styles */
+.top-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 20px;
+}
+
+.top-page h1 {
+  font-size: 2.5rem;
+  margin-bottom: 3rem;
+  color: #333;
+}
+
+.buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  max-width: 300px;
+}
+
+.btn {
+  display: block;
+  padding: 12px 24px;
+  font-size: 1rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: opacity 0.3s;
+  text-decoration: none;
+  text-align: center;
+}
+
+.btn:hover {
+  opacity: 0.8;
+}
+
+.btn-primary {
+  background-color: #007bff;
+  color: white;
+}
+
+.btn-secondary {
+  background-color: #6c757d;
+  color: white;
+}
+
+/* Games new page styles */
+.games-new {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-height: 100vh;
+  padding: 40px 20px;
+}
+
+.games-new h1 {
+  font-size: 2rem;
+  margin-bottom: 2rem;
+  color: #333;
+}
+
+.member-form {
+  width: 100%;
+  max-width: 400px;
+}
+
+.player-inputs {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.player-input {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.player-input label {
+  font-weight: bold;
+  color: #333;
+}
+
+.player-input input {
+  padding: 10px 12px;
+  font-size: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.player-input input:focus {
+  outline: none;
+  border-color: #007bff;
+}
+
+.form-actions {
+  margin-bottom: 2rem;
+}
+
+.form-actions .btn {
+  width: 100%;
+}
+
+.back-link {
+  margin-top: 1rem;
+}
+
+.back-link a {
+  color: #666;
   text-decoration: none;
 }
 
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
+.back-link a:hover {
+  text-decoration: underline;
+}
+
+/* Games show page styles */
+.games-show {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-height: 100vh;
+  padding: 40px 20px;
+}
+
+.games-show h1 {
+  font-size: 2rem;
+  margin-top: 0rem;
+  margin-bottom: 1rem;
+  color: #333;
+}
+
+.score-table {
+  width: 100%;
+  max-width: 600px;
+  border-collapse: collapse;
+  margin-bottom: 2rem;
+}
+
+.score-table th,
+.score-table td {
+  border: 1px solid #ccc;
+  padding: 10px 12px;
+  text-align: center;
+}
+
+.score-table thead th {
+  background-color: #e9ecef;
+  font-weight: bold;
+  color: #333;
+}
+
+.score-table tbody td:first-child {
+  background-color: #f8f9fa;
+  font-weight: bold;
+  color: #666;
+}
+
+.score-table tfoot td {
+  background-color: #e9ecef;
+  font-weight: bold;
+}
+
+.score-table .negative {
+  color: #dc3545;
+}
+
+.actions {
+  margin-bottom: 1rem;
+}
+
+/* Rounds new page styles */
+.rounds-new {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-height: 100vh;
+  padding: 32px 20px 48px;
+  background:
+    radial-gradient(circle at 15% 15%, #e2efff 0, #f4f8ff 50%, #e9f0fb 80%),
+    linear-gradient(135deg, rgba(148, 189, 238, 0.28), rgba(255, 255, 255, 0));
+  font-family: "Hiragino Maru Gothic ProN", "Yu Gothic", "Noto Sans JP", sans-serif;
+}
+
+.rounds-panel {
+  width: 100%;
+  max-width: 640px;
+  background: #f7fbff;
+  border: 2px solid #7b95c6;
+  border-radius: 10px;
+  box-shadow: 0 10px 20px rgba(48, 86, 138, 0.18);
+  padding: 18px 18px 22px;
+}
+
+.rounds-panel h1 {
+  font-size: 1.4rem;
+  margin: 0 0 12px;
+  color: #1f3b62;
+  letter-spacing: 0.02em;
+}
+
+.rounds-form {
+  width: 100%;
+}
+
+.scoreboard {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  background: #f4f8ff;
+  border: 2px solid #7b95c6;
+  border-radius: 6px;
+  overflow: hidden;
+  margin-bottom: 20px;
+}
+
+.scoreboard-caption {
+  caption-side: top;
+  text-align: center;
+  font-weight: 700;
+  color: #223a5a;
+  padding: 8px 0 6px;
+  background: #d9e6fb;
+  border-bottom: 2px solid #7b95c6;
+}
+
+.scoreboard thead th {
+  background: #dfe9fa;
+  color: #223a5a;
+  font-weight: 700;
+  padding: 10px 12px;
+  text-align: center;
+  border-bottom: 2px solid #7b95c6;
+}
+
+.scoreboard tbody td {
+  padding: 10px 12px;
+  border-bottom: 1px solid #b6c8e6;
+  border-right: 1px solid #b6c8e6;
+}
+
+.scoreboard tbody tr td:last-child {
+  border-right: none;
+}
+
+.scoreboard tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.player-name {
+  font-weight: 700;
+  color: #223552;
+}
+
+.score-cell {
+  width: 40%;
+}
+
+.score-field {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.score-input {
+  width: 120px;
+  max-width: 100%;
+  padding: 8px 10px;
+  font-size: 1rem;
+  border: 1px solid #8fa8cd;
+  border-radius: 6px;
+  text-align: right;
+  background: #ffffff;
+}
+
+.score-input:focus {
+  outline: none;
+  border-color: #577fbd;
+  box-shadow: 0 0 0 3px rgba(87, 127, 189, 0.2);
+}
+
+.score-unit {
+  font-weight: 700;
+  color: #35547a;
+}
+
+.score-unit--hundreds {
+  letter-spacing: 0.02em;
+}
+
+.form-error {
+  margin: 8px 0 16px;
+  padding: 10px 12px;
+  border: 1px solid #d27d7d;
+  border-radius: 8px;
+  background: #ffe9e9;
+  color: #7a1f1f;
+  font-weight: 700;
+}
+
+.validation-message {
+  margin: 10px 0 0;
+  color: #7a1f1f;
+  font-weight: 700;
+  text-align: center;
+}
+
+.scoreboard tfoot th,
+.scoreboard tfoot td {
+  background: #d9e6fb;
+  color: #223a5a;
+  font-weight: 700;
+  padding: 10px 12px;
+  border-top: 2px solid #7b95c6;
+}
+
+.scoreboard tfoot th {
+  text-align: left;
+}
+
+.score-total-value {
+  text-align: right;
+  border-left: 1px solid #b6c8e6;
+}
+
+.rounds-submit {
+  width: 100%;
+  background: linear-gradient(135deg, #2b66b5, #4c7fc5);
+  border-radius: 8px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+}
+
+.rounds-submit:disabled,
+.rounds-submit.is-disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.rounds-submit:hover {
+  opacity: 0.9;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -59,11 +59,13 @@ export default function Page() {
   }
 
   return (
-    <main style={{ padding: "2rem", textAlign: "center" }}>
+    <main className="top-page">
       <h1>麻雀スコア管理アプリ</h1>
-      <p>
-        <Link href="/games/new">新しく始める</Link>
-      </p>
+      <div className="buttons">
+        <Link href="/games/new" className="btn btn-primary">
+          新しく始める
+        </Link>
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary

- MPA 版 `application.css` のスタイルを `frontend/app/globals.css` に移植し、LIFF 版 4 画面（トップ／ゲーム作成／スコア一覧／点数入力）の見た目を MPA 版に揃える

closes #197

## 変更内容

- **CSS 移植**: MPA 版 376 行をそのまま移植。MPA に存在しないダークモード対応・リンク打ち消し（Next.js テンプレート由来）は撤去
- **トップ**: `.top-page` 構成、「新しく始める」を `.btn .btn-primary` に
- **ゲーム作成**: 見出しを MPA 版と同じ「メンバー入力」へ変更、`.member-form` / `.player-inputs` / `.rule-inputs` 構成に
- **スコア一覧**: `.score-table` 適用、マイナス点の赤字表示（`.negative`）、日付をゼロ埋め形式（YYYY/MM/DD）に統一、共有ボタンを `.share-section` 構成に
- **点数入力**: MPA 版と同じスコアボード構成（`.rounds-panel` / `.scoreboard` / caption / sr-only ラベル / 合計行）に変更

## Test plan

- [x] マイナス点に .negative クラスが付く（Vitest・TDD で追加）
- [x] 日付がゼロ埋め形式で表示される（Vitest・TDD で追加）
- [x] 既存フロントテスト全件パス（37 件）、ESLint・型チェッククリーン
- [x] ブラウザで MPA 版とスクリーンショット比較（スコア一覧・ゲーム作成・点数入力がほぼ一致）
- [x] 実機（LINE アプリ内）で確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)