### PR TITLE
feat: 本番composeにLIFF版(Next.js)のfrontendサービスを追加 (#203)

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -6,3 +6,21 @@ services:
         awslogs-region: ap-northeast-1
         awslogs-group: /mahjong-score/rails/production
         awslogs-create-group: "true"
+
+  # LIFF版（Next.js）。本番のみ常時稼働させるため production 側に定義する（#203）
+  frontend:
+    image: node:22
+    depends_on:
+      - web
+    working_dir: /app/frontend
+    volumes:
+      - .:/app
+    ports:
+      - "3001:3001"
+    environment:
+      API_BASE_URL: http://web:3000
+      NEXT_PUBLIC_LIFF_ID: ${NEXT_PUBLIC_LIFF_ID:-}
+    # ビルドはデプロイ時のみ実行する（クラッシュ復帰・EC2再起動を速くするため）:
+    #   docker-compose -f docker-compose.yml -f docker-compose.production.yml run --rm frontend bash -lc "npm ci && npm run build"
+    command: bash -lc "npm run start -- -p 3001"
+    restart: unless-stopped

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -9,7 +9,8 @@ services:
 
   # LIFF版（Next.js）。本番のみ常時稼働させるため production 側に定義する（#203）
   frontend:
-    image: node:22
+    # slim版を使用: 通常版(1.13GB)はEC2のディスク(8GB)を圧迫するため
+    image: node:22-slim
     depends_on:
       - web
     working_dir: /app/frontend


### PR DESCRIPTION
## Summary
- `docker-compose.production.yml` に frontend サービス（Next.js 本番稼働）を追加
- `image: node:22-slim`（メジャー固定・通常版はEC2ディスクを圧迫するためslim）/ ポート3001 / `API_BASE_URL=http://web:3000` / `restart: unless-stopped`
- ビルドはデプロイ時のみ実行し、起動時は成果物を再利用する（クラッシュ復帰・EC2再起動の高速化。#203の決定事項どおり）
- production 側に定義する理由（開発環境に無影響・変更最小）は #203 の決定事項を参照

## Test plan
- [x] RSpec 全件成功（pre-push フックで実行）
- [x] EC2 上で `next build` 実測（10分ライン判定）→ **28.3秒で合格・方式1（swap）確定**。結果は #203 にコメント済み
- [x] EC2 再起動で frontend が自動復帰することを確認 → **再起動後2分で全コンテナ自動復帰・frontend は成果物再利用で即起動**
- [x] EC2 内から curl で主要4画面の HTML が返ることを確認 → **4画面すべて 200**

## Fixes
- Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)
