### PR TITLE
feat: プレイヤー数が4人でないゲームの作成を拒否する (#192)

### DIFF
--- a/.claude/dependencies.md
+++ b/.claude/dependencies.md
@@ -5,13 +5,13 @@
 
 ## app/models/game.rb
 
-Game は Player・Round の親モデルであり、順位点計算ロジックを持つ。
+Game は Player・Round の親モデルであり、順位点計算ロジックと、ゲーム作成の入口となる `create_with_players!`（プレイヤーちょうど4人の検証を含む）を持つ。
 
 - `spec/models/game_spec.rb`（直接）
 - `spec/models/player_spec.rb`（has_many :players）
 - `spec/models/round_spec.rb`（has_many :rounds）
 - `spec/models/score_spec.rb`（calculate_ranking_scores が Score を参照）
-- `spec/requests/games_spec.rb`（Game の CRUD）
+- `spec/requests/games_spec.rb`（Game の CRUD。create は create_with_players! を呼ぶ）
 - `spec/requests/rounds_spec.rb`（Round 作成時に Game のルール設定を使用）
 - `spec/requests/api/v1/games_spec.rb`（JSON API。一覧・詳細・作成、順位点計算を含む）
 - `spec/requests/api/v1/rounds_spec.rb`（JSON API。Round 作成時に Game のルール設定を使用）
@@ -61,12 +61,22 @@ LIFF 版 JSON API の基底コントローラー。共通のシリアライズ�
 - `spec/requests/api/v1/games_spec.rb`（直接。一覧・詳細・作成）
 - `spec/requests/api/v1/rounds_spec.rb`（直接。Round 作成）
 
+## app/controllers/games_controller.rb
+
+MPA 版のゲーム作成・スコア一覧表示。作成は `Game.create_with_players!` に委譲し、失敗時はメンバー入力画面へリダイレクトする。
+
+- `spec/requests/games_spec.rb`（直接）
+- `spec/models/game_spec.rb`（create_with_players! と順位点計算 calculate_ranking_scores を使用）
+- `spec/models/player_spec.rb`（ゲーム作成時に Player も作成）
+- `e2e/home.spec.ts`（トップページからゲーム作成への導線）
+
 ## app/controllers/api/v1/games_controller.rb
 
-ゲームの一覧・詳細・作成を JSON で返す。詳細は Player・Round・順位点をネストして返す。
+ゲームの一覧・詳細・作成を JSON で返す。詳細は Player・Round・順位点をネストして返す。作成は `Game.create_with_players!` に委譲する。
 
 - `spec/requests/api/v1/games_spec.rb`（直接）
-- `spec/models/game_spec.rb`（順位点計算 calculate_ranking_scores を使用）
+- `spec/models/game_spec.rb`（create_with_players! と順位点計算 calculate_ranking_scores を使用）
+- `spec/requests/games_spec.rb`（MPA 版と同じ create_with_players! を共有するため、片方の変更が両経路に影響する）
 
 ## app/controllers/api/v1/rounds_controller.rb
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@
 
 ### 開発ツール
 
-- Cursor エディタ
+- VSCode
 - GitHub CLI（イシュー管理）
 - pry-rails / amazing_print（Rails コンソール）
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@
 
 ### 開発ツール
 
-- VSCode
+- Cursor エディタ
 - GitHub CLI（イシュー管理）
 - pry-rails / amazing_print（Rails コンソール）
 

--- a/app/controllers/api/v1/games_controller.rb
+++ b/app/controllers/api/v1/games_controller.rb
@@ -12,11 +12,7 @@ module Api
       end
 
       def create
-        game = nil
-        ActiveRecord::Base.transaction do
-          game = Game.create!(game_params)
-          player_names.each { |name| game.players.create!(name: name) }
-        end
+        game = Game.create_with_players!(game_params, player_names)
         render json: game_detail(game), status: :created
       rescue ActiveRecord::RecordInvalid => e
         render json: { errors: e.record.errors.full_messages }, status: :unprocessable_entity

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -12,11 +12,8 @@ class GamesController < ApplicationController
   end
 
   def create
-    ActiveRecord::Base.transaction do
-      game = Game.create!(game_params)
-      params[:players].each { |name| game.players.create!(name: name) }
-      redirect_to game_path(game)
-    end
+    game = Game.create_with_players!(game_params, params[:players])
+    redirect_to game_path(game)
   rescue ActiveRecord::RecordInvalid
     redirect_to new_game_path
   end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,10 +1,32 @@
 class Game < ApplicationRecord
+  # 順位点計算・ゼロサム検証が4人を前提にしているため、ゲームは4人固定とする
+  REQUIRED_PLAYER_COUNT = 4
+
   has_many :players
   has_many :rounds
 
   validates :mochi_ten, numericality: { only_integer: true, greater_than: 0 }
   validates :kaeshi_ten, numericality: { only_integer: true, greater_than: 0 }
   validate :rank_bonuses_must_be_zero_sum
+
+  # ゲーム作成とプレイヤー登録をまとめて行う。
+  # Game はプレイヤーより先に保存されるため人数を通常のバリデーションで検証できない。
+  # プレイヤーがちょうど4人でなければ ActiveRecord::RecordInvalid を投げ、全体をロールバックする。
+  def self.create_with_players!(attributes, player_names)
+    names = player_names.is_a?(Array) ? player_names : []
+
+    transaction do
+      game = new(attributes)
+      if names.size != REQUIRED_PLAYER_COUNT
+        game.errors.add(:base, "プレイヤーはちょうど#{REQUIRED_PLAYER_COUNT}人で登録してください")
+        raise ActiveRecord::RecordInvalid, game
+      end
+
+      game.save!
+      names.each { |name| game.players.create!(name: name) }
+      game
+    end
+  end
 
   def calculate_ranking_scores(round)
     bonuses = [rank_1_bonus, rank_2_bonus, rank_3_bonus, rank_4_bonus]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,7 +43,7 @@ flowchart TB
         rc["RoundsController<br>（点数バリデーション）"]
         agc["Api::V1::GamesController"]
         arc["Api::V1::RoundsController<br>（点数バリデーション）"]
-        model["Game モデル<br>calculate_ranking_scores<br>順位点計算・ゼロサム検証"]
+        model["Game モデル<br>create_with_players!（プレイヤー4人検証）<br>calculate_ranking_scores<br>順位点計算・ゼロサム検証"]
         db[("PostgreSQL<br>games / players<br>rounds / scores")]
     end
 
@@ -92,7 +92,7 @@ flowchart LR
 ```
 
 - コントローラーの点数検証の一本化は [#193](https://github.com/tsukamotohiroaki/mahjong_score/issues/193) で対応予定
-- 同じ「二重実装を増やさない」設計方針のゲーム作成検証は [#192](https://github.com/tsukamotohiroaki/mahjong_score/issues/192) を参照
+- ゲーム作成の「プレイヤーちょうど4人」検証は `Game.create_with_players!` に集約済み（[#192](https://github.com/tsukamotohiroaki/mahjong_score/issues/192)）。MPA・LIFF 両経路がこれを呼ぶため、上図の二重実装ペアには含まれない
 
 ## 読みどころ
 

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -62,6 +62,87 @@ RSpec.describe Game, type: :model do
     end
   end
 
+  describe '.create_with_players!' do
+    let(:four_names) { %w[Alice Bob Carol Dave] }
+
+    context 'プレイヤーが4人の場合' do
+      it 'Game が1件、Player が4件作成されること' do
+        expect {
+          Game.create_with_players!({}, four_names)
+        }.to change(Game, :count).by(1).and change(Player, :count).by(4)
+      end
+
+      it '作成した Game を返し、プレイヤーが入力順に紐づくこと' do
+        game = Game.create_with_players!({}, four_names)
+        expect(game).to be_a(Game)
+        expect(game.players.map(&:name)).to eq(four_names)
+      end
+
+      it '指定したルール設定が反映されること' do
+        game = Game.create_with_players!({ mochi_ten: 30000, kaeshi_ten: 30000,
+                                           rank_1_bonus: 30, rank_2_bonus: 10,
+                                           rank_3_bonus: -10, rank_4_bonus: -30 }, four_names)
+        expect(game.mochi_ten).to eq 30000
+        expect(game.rank_1_bonus).to eq 30
+      end
+    end
+
+    context 'プレイヤーが3人の場合' do
+      it 'ActiveRecord::RecordInvalid が発生し、Game と Player が作成されないこと' do
+        expect {
+          expect { Game.create_with_players!({}, %w[Alice Bob Carol]) }
+            .to raise_error(ActiveRecord::RecordInvalid)
+        }.to change(Game, :count).by(0).and change(Player, :count).by(0)
+      end
+    end
+
+    context 'プレイヤーが5人の場合' do
+      it 'ActiveRecord::RecordInvalid が発生し、Game と Player が作成されないこと' do
+        expect {
+          expect { Game.create_with_players!({}, %w[Alice Bob Carol Dave Eve]) }
+            .to raise_error(ActiveRecord::RecordInvalid)
+        }.to change(Game, :count).by(0).and change(Player, :count).by(0)
+      end
+    end
+
+    context 'プレイヤーが0人の場合' do
+      it 'ActiveRecord::RecordInvalid が発生し、Game と Player が作成されないこと' do
+        expect {
+          expect { Game.create_with_players!({}, []) }
+            .to raise_error(ActiveRecord::RecordInvalid)
+        }.to change(Game, :count).by(0).and change(Player, :count).by(0)
+      end
+    end
+
+    context 'プレイヤーが配列で渡されなかった場合' do
+      it 'nil なら ActiveRecord::RecordInvalid が発生し、Game と Player が作成されないこと' do
+        expect {
+          expect { Game.create_with_players!({}, nil) }
+            .to raise_error(ActiveRecord::RecordInvalid)
+        }.to change(Game, :count).by(0).and change(Player, :count).by(0)
+      end
+
+      it '文字列なら ActiveRecord::RecordInvalid が発生し、Game と Player が作成されないこと' do
+        expect {
+          expect { Game.create_with_players!({}, 'Alic') }
+            .to raise_error(ActiveRecord::RecordInvalid)
+        }.to change(Game, :count).by(0).and change(Player, :count).by(0)
+      end
+    end
+
+    context 'ルール設定が不正な場合' do
+      it 'ActiveRecord::RecordInvalid が発生し、Game と Player が作成されないこと' do
+        invalid_rule = { mochi_ten: 25000, kaeshi_ten: 30000,
+                         rank_1_bonus: 50, rank_2_bonus: 10,
+                         rank_3_bonus: -10, rank_4_bonus: -10 }
+        expect {
+          expect { Game.create_with_players!(invalid_rule, four_names) }
+            .to raise_error(ActiveRecord::RecordInvalid)
+        }.to change(Game, :count).by(0).and change(Player, :count).by(0)
+      end
+    end
+  end
+
   describe '#calculate_ranking_scores' do
     let(:game) { create(:game) }
     let(:players) do

--- a/spec/requests/api/v1/games_spec.rb
+++ b/spec/requests/api/v1/games_spec.rb
@@ -114,5 +114,55 @@ RSpec.describe "Api::V1::Games", type: :request do
         expect(response).to have_http_status(422)
       end
     end
+
+    context "プレイヤーが3人の場合" do
+      it "422とエラーJSONを返し、GameもPlayerも作成しない" do
+        params = valid_params.merge(players: %w[Alice Bob Carol])
+
+        expect {
+          post "/api/v1/games", params: params, as: :json
+        }.to change(Game, :count).by(0).and change(Player, :count).by(0)
+
+        expect(response).to have_http_status(422)
+        json = JSON.parse(response.body)
+        expect(json["errors"]).to include(a_string_including("4人"))
+      end
+    end
+
+    context "プレイヤーが5人の場合" do
+      it "422を返し、GameもPlayerも作成しない" do
+        params = valid_params.merge(players: %w[Alice Bob Carol Dave Eve])
+
+        expect {
+          post "/api/v1/games", params: params, as: :json
+        }.to change(Game, :count).by(0).and change(Player, :count).by(0)
+
+        expect(response).to have_http_status(422)
+      end
+    end
+
+    context "players が空配列の場合" do
+      it "422を返し、GameもPlayerも作成しない" do
+        params = valid_params.merge(players: [])
+
+        expect {
+          post "/api/v1/games", params: params, as: :json
+        }.to change(Game, :count).by(0).and change(Player, :count).by(0)
+
+        expect(response).to have_http_status(422)
+      end
+    end
+
+    context "players パラメータがない場合" do
+      it "422を返し、GameもPlayerも作成しない" do
+        params = valid_params.except(:players)
+
+        expect {
+          post "/api/v1/games", params: params, as: :json
+        }.to change(Game, :count).by(0).and change(Player, :count).by(0)
+
+        expect(response).to have_http_status(422)
+      end
+    end
   end
 end

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -87,6 +87,49 @@ RSpec.describe "Games", type: :request do
       end
     end
 
+    context "プレイヤーが3人の場合" do
+      let(:players) { ["Player1", "Player2", "Player3"] }
+
+      it "Game と Player が作成されない" do
+        expect {
+          post games_path, params: { players: players }
+        }.to change(Game, :count).by(0).and change(Player, :count).by(0)
+      end
+
+      it "メンバー入力画面にリダイレクトする" do
+        post games_path, params: { players: players }
+        expect(response).to redirect_to(new_game_path)
+      end
+    end
+
+    context "プレイヤーが5人の場合" do
+      let(:players) { ["Player1", "Player2", "Player3", "Player4", "Player5"] }
+
+      it "Game と Player が作成されない" do
+        expect {
+          post games_path, params: { players: players }
+        }.to change(Game, :count).by(0).and change(Player, :count).by(0)
+      end
+
+      it "メンバー入力画面にリダイレクトする" do
+        post games_path, params: { players: players }
+        expect(response).to redirect_to(new_game_path)
+      end
+    end
+
+    context "players パラメータがない場合" do
+      it "Game と Player が作成されない" do
+        expect {
+          post games_path, params: {}
+        }.to change(Game, :count).by(0).and change(Player, :count).by(0)
+      end
+
+      it "メンバー入力画面にリダイレクトする" do
+        post games_path, params: {}
+        expect(response).to redirect_to(new_game_path)
+      end
+    end
+
     context "ゼロサム条件を満たさないルール設定の場合" do
       let(:players) { ["Player1", "Player2", "Player3", "Player4"] }
       let(:invalid_rule_params) do


### PR DESCRIPTION
## Summary
- ゲーム作成時に「プレイヤーはちょうど4人」を検証し、4人以外なら MPA・API の両経路で作成を拒否する（3人・5人・players なしのいずれも API は 422、MPA はメンバー入力画面へリダイレクト）
- 検証の置き場所として `Game.create_with_players!`（ゲーム作成 + プレイヤー登録 + 人数検証をまとめたクラスメソッド）を新設し、両コントローラーの二重実装を避けて1箇所に集約した（#193 と同じ設計方針の先行事例）
- 従来 MPA で `players` パラメータなしの POST が `NoMethodError`（500）になっていた問題も、この集約により解消
- TDD で実施：リクエストスペック・モデルスペックを先に追加して Red を確認してから実装。既存スペックは1件も変更せず全件グリーンのまま（97 examples, 0 failures）
- あわせて `.claude/dependencies.md`・`docs/architecture.md` を更新
- 補足: CLAUDE.md の変更（VSCode への更新）は誤ってこのブランチに含めたため revert で取り消し、#223 に分離した。本 PR の差分に CLAUDE.md は含まれない

## Test plan
- [x] API: 3人 / 5人 / 空配列 / players なしで POST → 422 が返り、Game・Player とも作成されない
- [x] MPA: 3人 / 5人 / players なしで POST → メンバー入力画面へリダイレクトし、何も作成されない
- [x] 4人での正常作成が引き続き成功する（既存スペックが変更なしでグリーンのまま）
- [x] rspec 全件パス（97 examples, 0 failures）
- [x] 実サーバーで curl による動作確認（API: 3人/5人/なし → 422、4人 → 201。MPA: 4人 → スコア一覧へ、3人 → 入力画面へ）

## Fixes
- Fixes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5ZLzSE2d5qTgvZbyp63Kf