### PR TITLE
README を claudian 風のデザインに刷新

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,78 @@
 # Mahjong Score
 
-麻雀の半荘結果を記録・集計できるスコア管理アプリ（Web）
+<p>
+  <a href="https://github.com/tsukamotohiroaki/mahjong_score/actions/workflows/ci.yml">
+    <img src="https://github.com/tsukamotohiroaki/mahjong_score/actions/workflows/ci.yml/badge.svg" alt="CI" vspace="10">
+  </a>
+  <img src="https://img.shields.io/badge/version-v0.2.0-blue" alt="Version" vspace="10">
+  <img src="https://img.shields.io/badge/Ruby-3.3-CC342D?logo=ruby&logoColor=white" alt="Ruby 3.3" vspace="10">
+  <img src="https://img.shields.io/badge/Rails-7.1-D30001?logo=rubyonrails&logoColor=white" alt="Rails 7.1" vspace="10">
+  <img src="https://img.shields.io/badge/PostgreSQL-16-4169E1?logo=postgresql&logoColor=white" alt="PostgreSQL 16" vspace="10">
+  <img src="https://img.shields.io/badge/Hotwire-Turbo%20%2B%20Stimulus-FFE801?logo=hotwire&logoColor=black" alt="Hotwire" vspace="10">
+  <img src="https://img.shields.io/badge/Docker-Compose-2496ED?logo=docker&logoColor=white" alt="Docker Compose" vspace="10">
+</p>
 
-## 技術スタック
+麻雀の半荘結果を記録し、順位点まで自動計算するシンプルなスコア管理アプリ 🀄
 
-- Ruby 3.3.10
-- Rails 7.1.3
-- PostgreSQL 16
-- Docker / Docker Compose
-- Hotwire (Turbo + Stimulus)
+MPA（Rails + ERB + Hotwire）で MVP を最短リリースし、動かしたまま LIFF 版（Next.js）へ段階的に移行しています（ストラングラーフィグパターン）。
 
-## 必要なもの
+## Features
+
+**対局の記録** — 4人固定のゲームを作成し、半荘（ラウンド）ごとに素点を入力。ゲーム作成とプレイヤー登録はトランザクションでまとめて行い、不整合を防ぎます。
+
+**順位点の自動計算** — 持ち点・返し点・順位点（ウマ）をゲームごとのルールとして設定。順位点はゼロサム検証つきで、同点時は該当順位のボーナスを均等分配します。
+
+**JSON API** — LIFF 版（Next.js）向けの `/api/v1` エンドポイント。OpenAPI 3.0 仕様書（[`docs/openapi.yaml`](docs/openapi.yaml)）を MPA 版と LIFF 版の「契約」として運用しています。
+
+**Hotwire スタック** — importmap-rails + Turbo + Stimulus。バンドラー不要の Rails 標準構成です。
+
+**TDAD（Test-Driven Agentic Development）** — AI エージェント（Claude Code）との協働開発で、依存マップ（`.claude/dependencies.md`）を起点にデグレを防ぐ運用をしています。
+
+## Quick Start
+
+### 必要なもの
 
 - Docker Desktop（または Docker Engine + Docker Compose）
 
-## セットアップ
+### 起動手順
 
-### 1. リポジトリをクローン
+1. リポジトリをクローンする:
 
-```bash
-git clone <repository-url>
-cd mahjong_score
-```
+   ```bash
+   git clone <repository-url>
+   cd mahjong_score
+   ```
 
-### 2. コンテナを起動
+2. コンテナを起動する（初回は gem のインストールが自動で走ります）:
 
-```bash
-docker compose up
-```
+   ```bash
+   docker compose up
+   ```
 
-初回起動時は以下が自動で実行されます：
-- gem のインストール（`bundle install`）
-- Rails サーバーの起動
+3. データベースを作成する（初回のみ、別ターミナルで）:
 
-### 3. データベースを作成（初回のみ）
+   ```bash
+   docker compose exec web bin/rails db:create db:migrate
+   ```
 
-別ターミナルで以下を実行：
+4. http://localhost:3000 にアクセスする 🎉
 
-```bash
-docker compose exec web bin/rails db:create db:migrate
-```
+## Commands
 
-### 4. アクセス
+よく使うコマンドの早見表です。
 
-http://localhost:3000
+| やりたいこと | コマンド |
+|---|---|
+| サーバー起動 | `docker compose up` |
+| Rails コンソール | `docker compose exec web bin/rails console` |
+| マイグレーション実行 | `docker compose exec web bin/rails db:migrate` |
+| ルーティング確認 | `docker compose exec web bin/rails routes` |
+| RSpec 実行 | `docker compose run --rm -e RAILS_ENV=test web bash -lc "bundle install && bundle exec rspec"` |
+| E2E テスト（ホスト） | `npx playwright test` ※事前に `docker compose up` でアプリを起動 |
+| E2E テスト（Docker） | `docker compose run --rm playwright` |
 
-## よく使うコマンド
-
-### コンテナ操作
+<details>
+<summary><b>コンテナ操作</b></summary>
 
 ```bash
 # 起動（フォアグラウンド）
@@ -63,35 +88,26 @@ docker compose down
 docker compose down -v
 ```
 
-### Rails コマンド
+</details>
+
+<details>
+<summary><b>Rails ジェネレーター</b></summary>
 
 ```bash
-# Rails コンソール
-docker compose exec web bin/rails console
-
-# マイグレーション実行
-docker compose exec web bin/rails db:migrate
-
 # マイグレーション作成
 docker compose exec web bin/rails generate migration AddColumnToTable
 
 # モデル生成
 docker compose exec web bin/rails generate model ModelName field:type
 
-# ルーティング確認
-docker compose exec web bin/rails routes
-
-# RSpec実行
-docker compose run --rm -e RAILS_ENV=test web bash -lc "bundle install && bundle exec rspec"
-
-# E2Eテスト実行（ホスト）※ 事前に docker compose up でアプリを起動しておく
-npx playwright test
-
-# E2Eテスト実行（Docker）
-docker compose run --rm playwright
+# Stimulus コントローラー生成
+docker compose exec web bin/rails generate stimulus controller_name
 ```
 
-### その他
+</details>
+
+<details>
+<summary><b>その他</b></summary>
 
 ```bash
 # コンテナ内でシェルを開く
@@ -102,41 +118,51 @@ docker compose logs -f web
 
 # gem 追加後の反映
 docker compose exec web bundle install
+
+# OpenAPI 仕様書の構文チェック
+npx @redocly/cli lint docs/openapi.yaml
 ```
 
-## Hotwire（Turbo + Stimulus）
+</details>
 
-Rails 標準の Hotwire スタックを使用しています。
+## Architecture
 
-### 構成
-
-- **importmap-rails**: JSモジュールの配信（バンドラー不要）
-- **Turbo**: ページ遷移の高速化（Turbo Drive）
-- **Stimulus**: HTML属性ベースの軽量JSフレームワーク
-
-### Stimulus コントローラーの追加方法
-
-```bash
-# コントローラーを作成
-docker compose exec web bin/rails generate stimulus controller_name
-```
-
-`app/javascript/controllers/` にファイルが生成されます。
-
-### ファイル構成
+MPA 版 + JSON API + LIFF 版の併存構成です。全体像は [`docs/architecture.md`](docs/architecture.md) を参照してください。
 
 ```
-app/javascript/
-├── application.js                 # エントリーポイント（Turbo + Stimulus を読み込み）
-└── controllers/
-    ├── application.js             # Stimulus アプリケーション設定
-    ├── index.js                   # コントローラーの自動読み込み
-    └── hello_controller.js        # サンプルコントローラー
-config/
-└── importmap.rb                   # JSモジュールのピン定義
+mahjong_score/
+├── app/
+│   ├── controllers/            # MPA 版コントローラー + api/v1（JSON API）
+│   ├── javascript/             # Stimulus コントローラー等
+│   ├── models/                 # Game / Player / Round / Score
+│   └── views/                  # ERB テンプレート
+├── config/
+│   ├── database.yml            # DB 設定
+│   └── routes.rb               # ルーティング
+├── db/
+│   ├── migrate/                # マイグレーションファイル
+│   └── schema.rb               # スキーマ定義
+├── docs/
+│   ├── architecture.md         # アーキテクチャ構成図（Mermaid）
+│   └── openapi.yaml            # API 仕様書（OpenAPI 3.0）
+├── e2e/                        # E2E テスト（Playwright）
+├── frontend/                   # LIFF 版（Next.js）
+├── infra/                      # CloudFormation テンプレート等
+├── spec/                       # RSpec（モデル・リクエスト）
+├── docker-compose.yml          # 開発環境の Docker Compose 設定
+└── Gemfile                     # gem 定義
 ```
 
-### Stimulus コントローラーの使い方
+### Hotwire（Turbo + Stimulus）
+
+- **importmap-rails** — JS モジュールの配信（バンドラー不要）
+- **Turbo** — ページ遷移の高速化（Turbo Drive）
+- **Stimulus** — HTML 属性ベースの軽量 JS フレームワーク
+
+<details>
+<summary><b>Stimulus コントローラーの使い方</b></summary>
+
+`bin/rails generate stimulus controller_name` で `app/javascript/controllers/` にファイルが生成されます。
 
 ```erb
 <!-- ビューで data-controller 属性を指定 -->
@@ -156,52 +182,32 @@ export default class extends Controller {
 }
 ```
 
-## API 仕様書（OpenAPI）
-
-`docs/openapi.yaml` に OpenAPI 3.0 形式の API 仕様書があります。
-6月の Rails API 化で実装する予定のエンドポイント設計を記載しています。
-
-### 構文チェック
-
-```bash
-npx @redocly/cli lint docs/openapi.yaml
+```
+app/javascript/
+├── application.js                 # エントリーポイント（Turbo + Stimulus を読み込み）
+└── controllers/
+    ├── application.js             # Stimulus アプリケーション設定
+    ├── index.js                   # コントローラーの自動読み込み
+    └── hello_controller.js        # サンプルコントローラー
+config/
+└── importmap.rb                   # JS モジュールのピン定義
 ```
 
-## CI（GitHub Actions）
+</details>
 
-`main` ブランチへの push / PR で以下が自動実行されます：
+## Testing & CI
 
-- **RSpec**: モデル・リクエストスペック
-- **Playwright E2E**: ブラウザでのユーザー操作テスト
+| レイヤー | ツール | 役割 |
+|---|---|---|
+| 単体・リクエスト | RSpec + FactoryBot | サーバー側の品質保証（モデル・コントローラー） |
+| E2E | Playwright | ブラウザ側の品質保証（JS 動作・ユーザー操作フロー） |
+| 探索的テスト | Claude in Chrome | ビジュアル確認・仕様の抜け漏れ発見（ベータ） |
 
-E2E テストが失敗した場合、スクリーンショットと動画が Artifacts として保存されます。
-GitHub の Actions タブ → 該当ワークフロー → `playwright-report` から確認できます。
+`main` ブランチへの push / PR で GitHub Actions により **RSpec** と **Playwright E2E** が自動実行されます。
 
-## ディレクトリ構成（主要部分）
+> **Note**: E2E テストが失敗した場合、スクリーンショットと動画が Artifacts として保存されます。GitHub の Actions タブ → 該当ワークフロー → `playwright-report` から確認できます。
 
-```
-mahjong_score/
-├── app/
-│   ├── controllers/    # コントローラー
-│   ├── javascript/     # JS（Stimulus コントローラー等）
-│   ├── models/         # モデル
-│   └── views/          # ビュー
-├── config/
-│   ├── database.yml    # DB設定
-│   └── routes.rb       # ルーティング
-├── db/
-│   ├── migrate/        # マイグレーションファイル
-│   └── schema.rb       # スキーマ定義
-├── docs/
-│   └── openapi.yaml    # API 仕様書（OpenAPI 3.0）
-├── e2e/                # E2Eテスト（Playwright）
-├── docker-compose.yml  # Docker Compose 設定
-└── Gemfile             # gem 定義
-```
-
-## 本番環境（AWS）
-
-### 構成
+## Production（AWS）
 
 - EC2（t2.micro）+ RDS（PostgreSQL 16）
 - CloudFormation でインフラをコード化（`infra/cloudformation.yml`）
@@ -214,9 +220,10 @@ mahjong_score/
 3. コンテナを再起動する（`docker-compose up -d`）
 4. 本番環境で動作確認する
 
-### systemd サービスの設定（初回のみ）
+<details>
+<summary><b>systemd サービスの設定（初回のみ）</b></summary>
 
-EC2 再起動時にアプリが自動起動するよう設定する：
+EC2 再起動時にアプリが自動起動するよう設定する:
 
 ```bash
 sudo cp infra/mahjong-score.service /etc/systemd/system/
@@ -226,9 +233,12 @@ sudo systemctl enable mahjong-score
 
 ※ CloudFormation で新規構築した場合は UserData で自動設定済み
 
-## トラブルシューティング
+</details>
 
-### `localhost:3000` にアクセスできない
+## Troubleshooting
+
+<details>
+<summary><b><code>localhost:3000</code> にアクセスできない</b></summary>
 
 ```bash
 # コンテナが起動しているか確認
@@ -238,17 +248,23 @@ docker compose ps
 docker compose logs web
 ```
 
-### DB 接続エラー
+</details>
+
+<details>
+<summary><b>DB 接続エラー</b></summary>
 
 ```bash
 # DB コンテナが起動しているか確認
 docker compose ps
 
-# DB を再作成
+# DB を再作成（データは消える）
 docker compose exec web bin/rails db:drop db:create db:migrate
 ```
 
-### gem のインストールエラー
+</details>
+
+<details>
+<summary><b>gem のインストールエラー</b></summary>
 
 ```bash
 # コンテナを再ビルド
@@ -256,23 +272,25 @@ docker compose down
 docker compose up --build
 ```
 
-## TDAD（Test-Driven Agentic Development）
+</details>
 
-AI エージェント（Claude Code）との協働開発で、変更時のデグレを防ぐために依存マップを運用しています。
+## Development
 
-- `.claude/dependencies.md` に、ソースコードとテストの依存関係を記載
-- コード変更前にこのファイルを確認し、影響を受けるテストを把握してから作業する
-- 「気をつける」ではなく「気をつけなくても壊れない仕組み」で品質を守る
+Issue 駆動 + TDD（テスト駆動開発）で進めます。
 
-## 開発メモ
-- `chore/initial-setup` ブランチ: Rails + Docker + PostgreSQL の初期構成保存用（以後更新しない）
-
-## 開発フロー
 1. イシューを作成する
-2. ブランチを切る
+2. ブランチを切る（`feature/` `fix/` `chore/`）
 3. テストを書く（TDD: Red → Green → Refactor）
 4. 実装する
 5. 動作確認する
-6. PRを作成する
+6. PR を作成する（ベースブランチは `main`）
 7. マージする
-8. イシューをCloseする
+8. イシューを Close する
+
+コード変更前に `.claude/dependencies.md` を確認し、影響を受けるテストを把握してから作業します（TDAD）。「気をつける」ではなく「気をつけなくても壊れない仕組み」で品質を守ります。
+
+> **Note**: `chore/initial-setup` ブランチは Rails + Docker + PostgreSQL の初期構成保存用です（以後更新しない）。
+
+---
+
+関連ドキュメント: [アーキテクチャ構成図](docs/architecture.md) · [API 仕様書（OpenAPI）](docs/openapi.yaml) · [LIFF 版 frontend](frontend/README.md) · [CLAUDE.md](CLAUDE.md)


### PR DESCRIPTION
- 冒頭にバッジ列（CI・バージョン・技術スタック）とキャッチコピーを追加
- 機能紹介を太字リード形式の Features セクションに整理
- よく使うコマンドを早見表（テーブル）+ 折りたたみ（details）に再構成
- ディレクトリツリーに frontend / infra / spec を追記
- テスト戦略と CI を Testing & CI セクションに統合
- トラブルシューティングを折りたたみ形式に変更
- 末尾に関連ドキュメントへのリンクを追加

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L3rpqmibRLkj2UkXGPPQEz