### PR TITLE
セッション開始フックで Docker デーモンを自動起動する (#227)

### DIFF
--- a/.claude/hooks/session-start-info.sh
+++ b/.claude/hooks/session-start-info.sh
@@ -20,4 +20,29 @@ else
   echo "差分なし（最新状態）"
 fi
 
+# クラウド環境（Linux・systemdなし）では dockerd が自動起動しないため、ここで起動する。
+# macOS では Docker Desktop がデーモンを管理するので絶対に干渉しない（Linux 以外は何もしない）。
+if [ "$(uname)" = "Linux" ] && command -v dockerd >/dev/null 2>&1; then
+  echo ""
+  echo "=== Docker デーモン ==="
+  if docker info >/dev/null 2>&1; then
+    echo "起動済み"
+  else
+    setsid dockerd >/var/log/dockerd.log 2>&1 < /dev/null &
+    STARTED=false
+    for _ in $(seq 1 30); do
+      if docker info >/dev/null 2>&1; then
+        STARTED=true
+        break
+      fi
+      sleep 1
+    done
+    if [ "$STARTED" = "true" ]; then
+      echo "停止していたため自動起動しました"
+    else
+      echo "起動に失敗しました（ログ: /var/log/dockerd.log）"
+    fi
+  fi
+fi
+
 exit 0

--- a/.claude/hooks/session-start-info.sh
+++ b/.claude/hooks/session-start-info.sh
@@ -28,19 +28,33 @@ if [ "$(uname)" = "Linux" ] && command -v dockerd >/dev/null 2>&1; then
   if docker info >/dev/null 2>&1; then
     echo "起動済み"
   else
-    setsid dockerd >/var/log/dockerd.log 2>&1 < /dev/null &
+    # 非 root など /var/log に書けない環境では /tmp に逃がす（案内するパスと実際の出力先を一致させる）
+    DOCKERD_LOG=/var/log/dockerd.log
+    # 2>/dev/null を先に置く（リダイレクトは左から処理されるため、後ろだとエラーが漏れる）
+    : 2>/dev/null >"$DOCKERD_LOG" || DOCKERD_LOG=/tmp/dockerd.log
+    setsid dockerd >"$DOCKERD_LOG" 2>&1 < /dev/null &
+    # 起動は実測で1〜2秒。序盤を細かく見て成功を早く拾い、待ち続けても10秒で打ち切る
     STARTED=false
-    for _ in $(seq 1 30); do
+    for _ in $(seq 1 10); do
       if docker info >/dev/null 2>&1; then
         STARTED=true
         break
       fi
-      sleep 1
+      sleep 0.2
     done
+    if [ "$STARTED" = "false" ]; then
+      for _ in $(seq 1 8); do
+        if docker info >/dev/null 2>&1; then
+          STARTED=true
+          break
+        fi
+        sleep 1
+      done
+    fi
     if [ "$STARTED" = "true" ]; then
       echo "停止していたため自動起動しました"
     else
-      echo "起動に失敗しました（ログ: /var/log/dockerd.log）"
+      echo "10秒以内に起動を確認できませんでした（起動途中の可能性があります。ログ: $DOCKERD_LOG）"
     fi
   fi
 fi


### PR DESCRIPTION
## Summary
- クラウド開発環境（Linux・systemd なし）ではセッション開始時に `dockerd` が起動しておらず、毎回手動起動が必要だった
- `.claude/hooks/session-start-info.sh` に「OS が Linux、かつ `dockerd` が存在し、かつデーモンが停止している場合のみ起動する」処理を追加した
- 起動結果（起動済み / 自動起動した / 失敗した）をセッション開始時の出力に表示する
- macOS（Docker Desktop の管理範囲）や Docker が存在しない環境ではセクション自体を出力せず何もしない。フックは常に `exit 0` で終了し、セッション開始を妨げない

## 追加修正（レビュー指摘対応）
- **起動待ちの上限を 30秒 → 10秒に短縮**（`1秒×30回` → `0.2秒×10回 + 1秒×8回`）。クラウド環境での実測が約1.7秒だったため十分なマージンがある。起動できない環境でセッション開始のたびに30秒ブロックされる問題を解消
- **ログ出力先のフォールバックを追加**。`/var/log/dockerd.log` に書けない場合は `/tmp/dockerd.log` を使う。非 root 環境で `Permission denied` が出力され、かつ実際には書けていないパスを「ログはここ」と案内していた問題を解消
- 失敗時のメッセージを実態に合わせ「10秒以内に起動を確認できませんでした（起動途中の可能性があります）」に変更

## Test plan
- [x] クラウド環境で新規セッション相当の状態（デーモン停止中）からフックを実行し、自動起動後に `docker compose up` が成功する
- [x] デーモン起動済みの状態で再実行しても干渉せず「起動済み」と表示される
- [x] macOS 相当（`uname` が Darwin を返す環境で模擬）では Docker セクションが表示されず、既存出力のみで正常終了する
- [x] `dockerd` が存在しない環境（PATH から除外して模擬）でもエラーなく `exit 0` する
- [x] 既存の出力（git status・ブランチ・リモート差分）が従来どおり表示される
- [x] RSpec 全 97 件パス（push 前フックで実行）

### 追加修正の検証（Linux コンテナ `ruby:3.3.10` で `dockerd`/`docker` をスタブ化）
- [x] 起動失敗が続く場合に **10〜11秒で打ち切る**（修正前は30秒。Red→Green を確認）
- [x] 起動成功の検知は従来どおり（約1.0秒で検知。回帰なし）
- [x] 非 root 実行時に `Permission denied` が出力されない（修正前は出力されていた）
- [x] 非 root 実行時に案内されるログパスが `/tmp/dockerd.log` になり、**実際に書き込み可能**であることを確認
- [x] `dockerd` なし / デーモン起動済み の各シナリオで回帰なし（全13アサーション GREEN）
- [x] macOS 実機でセクション非表示・出力の骨格が `main` と完全一致・`exit 0`
- [x] `bash -n` による構文チェック

## Fixes
- Fixes #227
