### PR TITLE
点数バリデーションを RoundScoreForm に一本化

### DIFF
--- a/.claude/dependencies.md
+++ b/.claude/dependencies.md
@@ -80,7 +80,25 @@ MPA 版のゲーム作成・スコア一覧表示。作成は `Game.create_with_
 
 ## app/controllers/api/v1/rounds_controller.rb
 
-ラウンド（点数）入力を JSON で受け付ける。入力は百点棒単位、保存時に 100 倍する。
+ラウンド（点数）入力を JSON で受け付ける。検証は `RoundScoreForm` に委譲し、保存時に百点棒単位を 100 倍する。
 
 - `spec/requests/api/v1/rounds_spec.rb`（直接）
 - `spec/requests/api/v1/games_spec.rb`（作成したラウンドはゲーム詳細に反映される）
+- `spec/forms/round_score_form_spec.rb`（検証ロジックの実体）
+
+## app/controllers/rounds_controller.rb
+
+MPA 版のラウンド（点数）入力。検証は `RoundScoreForm` に委譲し、失敗時は一律メッセージで入力画面を再表示する。
+
+- `spec/requests/rounds_spec.rb`（直接）
+- `spec/forms/round_score_form_spec.rb`（検証ロジックの実体）
+- `e2e/score_input.spec.ts`（点数入力フロー）
+
+## app/forms/round_score_form.rb
+
+点数入力（整数・±1000・合計1000。百点棒単位）の検証を MPA / API 共通で担うフォームオブジェクト。ここを変更すると両経路の受け付け条件が同時に変わる。
+
+- `spec/forms/round_score_form_spec.rb`（直接）
+- `spec/requests/rounds_spec.rb`（MPA 経路の配線。エラー時 422 / 再表示）
+- `spec/requests/api/v1/rounds_spec.rb`（API 経路の配線。エラー時 422 / 原因別メッセージ）
+- `e2e/score_input.spec.ts`（点数入力 → バリデーションエラー表示）

--- a/app/controllers/api/v1/rounds_controller.rb
+++ b/app/controllers/api/v1/rounds_controller.rb
@@ -1,22 +1,21 @@
 module Api
   module V1
     class RoundsController < Api::V1::ApplicationController
-      MIN_UNIT = -1000
-      MAX_UNIT = 1000
-      REQUIRED_TOTAL = 1000
-
       def create
         game = Game.find(params[:game_id])
 
-        errors = validation_errors(game)
-        return render json: { errors: errors }, status: :unprocessable_entity if errors.any?
+        form = RoundScoreForm.new(
+          players: game.players,
+          raw_scores: score_entries.to_h { |entry| [entry[:player_id].to_i, entry[:point]] }
+        )
+        return render json: { errors: form.errors.full_messages }, status: :unprocessable_entity if form.invalid?
 
         round = game.rounds.find_or_initialize_by(round_number: next_round_number(game))
         ActiveRecord::Base.transaction do
           round.save! if round.new_record?
           game.players.each do |player|
             score = round.scores.find_or_initialize_by(player: player)
-            score.update!(point: score_map[player.id] * 100)
+            score.update!(point: form.units_by_player_id[player.id] * 100)
           end
         end
 
@@ -29,26 +28,8 @@ module Api
         params.fetch(:scores, [])
       end
 
-      # player_id => 百点棒単位の点数（整数）。整数に変換できない値は nil。
-      def score_map
-        @score_map ||= score_entries.each_with_object({}) do |entry, hash|
-          raw = entry[:point]
-          hash[entry[:player_id].to_i] = raw.to_s.match?(/\A-?\d+\z/) ? raw.to_i : nil
-        end
-      end
-
       def next_round_number(game)
         params[:round_number].presence&.to_i || game.rounds.maximum(:round_number).to_i + 1
-      end
-
-      def validation_errors(game)
-        units = game.players.map { |player| score_map[player.id] }
-
-        return ["点数は全プレイヤー分を整数で入力してください"] if units.any?(&:nil?)
-        return ["点数は #{MIN_UNIT}〜#{MAX_UNIT} の範囲で入力してください"] if units.any? { |u| u < MIN_UNIT || u > MAX_UNIT }
-        return ["点数の合計が #{REQUIRED_TOTAL} になりません"] if units.sum != REQUIRED_TOTAL
-
-        []
       end
     end
   end

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -12,28 +12,12 @@ class RoundsController < ApplicationController
     @score_values = params.fetch(:scores, {})
     requested_round_number = params[:round_number].presence&.to_i
     @round_number = requested_round_number || @game.rounds.maximum(:round_number).to_i + 1
-    min_unit = -1000
-    max_unit = 1000
+    form = RoundScoreForm.new(
+      players: @players,
+      raw_scores: @players.to_h { |player| [player.id, @score_values[player.id.to_s]] }
+    )
 
-    score_units = @players.map do |player|
-      raw = @score_values[player.id.to_s]
-      next if raw.blank?
-      next unless raw.match?(/\A-?\d+\z/)
-
-      raw.to_i
-    end
-
-    if score_units.any?(&:nil?)
-      @error_message = "入力内容を確認してください"
-      return render :new, status: 422
-    end
-
-    if score_units.any? { |unit| unit < min_unit || unit > max_unit }
-      @error_message = "入力内容を確認してください"
-      return render :new, status: 422
-    end
-
-    if score_units.sum != 1000
+    if form.invalid?
       @error_message = "入力内容を確認してください"
       return render :new, status: 422
     end
@@ -42,9 +26,9 @@ class RoundsController < ApplicationController
 
     ActiveRecord::Base.transaction do
       round.save! if round.new_record?
-      @players.each_with_index do |player, index|
+      @players.each do |player|
         score = round.scores.find_or_initialize_by(player: player)
-        score.update!(point: score_units[index] * 100)
+        score.update!(point: form.units_by_player_id[player.id] * 100)
       end
     end
 

--- a/app/forms/round_score_form.rb
+++ b/app/forms/round_score_form.rb
@@ -1,0 +1,40 @@
+# 局の点数入力（4人分一括）の検証を MPA / API 共通で担うフォームオブジェクト。
+# 入力は百点棒単位（実点数の 1/100）で受け取る。
+class RoundScoreForm
+  include ActiveModel::Model
+
+  MIN_UNIT = -1000
+  MAX_UNIT = 1000
+  REQUIRED_TOTAL = 1000
+
+  # players: 対象ゲームの全プレイヤー
+  # raw_scores: { player_id(Integer) => 入力値 } に正規化済みのハッシュ
+  def initialize(players:, raw_scores:)
+    @players = players
+    @raw_scores = raw_scores
+  end
+
+  validate :scores_must_satisfy_rules
+
+  # player_id => 百点棒単位の点数（整数）。整数に変換できない値・未入力は nil。
+  def units_by_player_id
+    @units_by_player_id ||= @players.each_with_object({}) do |player, hash|
+      raw = @raw_scores[player.id]
+      hash[player.id] = raw.to_s.match?(/\A-?\d+\z/) ? raw.to_i : nil
+    end
+  end
+
+  private
+
+  def scores_must_satisfy_rules
+    units = units_by_player_id.values
+
+    if units.any?(&:nil?)
+      errors.add(:base, "点数は全プレイヤー分を整数で入力してください")
+    elsif units.any? { |unit| unit < MIN_UNIT || unit > MAX_UNIT }
+      errors.add(:base, "点数は #{MIN_UNIT}〜#{MAX_UNIT} の範囲で入力してください")
+    elsif units.sum != REQUIRED_TOTAL
+      errors.add(:base, "点数の合計が #{REQUIRED_TOTAL} になりません")
+    end
+  end
+end

--- a/spec/forms/round_score_form_spec.rb
+++ b/spec/forms/round_score_form_spec.rb
@@ -1,0 +1,105 @@
+require "rails_helper"
+
+RSpec.describe RoundScoreForm do
+  let(:game) { create(:game) }
+  let(:players) { create_list(:player, 4, game: game) }
+
+  def build_form(raw_scores)
+    described_class.new(players: players, raw_scores: raw_scores)
+  end
+
+  # プレイヤー4人に順番に値を割り当てた raw_scores を作る
+  def scores_for(*values)
+    players.zip(values).to_h { |player, value| [player.id, value] }
+  end
+
+  describe "正常系" do
+    it "整数4人分・合計1000なら有効" do
+      form = build_form(scores_for("450", "250", "200", "100"))
+      expect(form).to be_valid
+    end
+
+    it "負の値を含む合計1000も有効" do
+      form = build_form(scores_for("500", "400", "200", "-100"))
+      expect(form).to be_valid
+    end
+
+    it "境界値 +1000 / -1000 ちょうどは有効" do
+      form = build_form(scores_for("1000", "1000", "-1000", "0"))
+      expect(form).to be_valid
+    end
+  end
+
+  describe "範囲外" do
+    it "+1001 は無効" do
+      form = build_form(scores_for("1001", "999", "-1000", "0"))
+      expect(form).to be_invalid
+      expect(form.errors.full_messages).to eq(["点数は -1000〜1000 の範囲で入力してください"])
+    end
+
+    it "-1001 は無効" do
+      form = build_form(scores_for("1000", "1000", "-1001", "1"))
+      expect(form).to be_invalid
+      expect(form.errors.full_messages).to eq(["点数は -1000〜1000 の範囲で入力してください"])
+    end
+  end
+
+  describe "整数でない入力" do
+    ["", "1.5", "abc", "２５０"].each do |invalid_value|
+      it "#{invalid_value.inspect} を含むと無効" do
+        form = build_form(scores_for("450", "250", "200", invalid_value))
+        expect(form).to be_invalid
+        expect(form.errors.full_messages).to eq(["点数は全プレイヤー分を整数で入力してください"])
+      end
+    end
+  end
+
+  describe "合計不一致" do
+    it "合計999は無効" do
+      form = build_form(scores_for("450", "250", "200", "99"))
+      expect(form).to be_invalid
+      expect(form.errors.full_messages).to eq(["点数の合計が 1000 になりません"])
+    end
+
+    it "合計1001は無効" do
+      form = build_form(scores_for("450", "250", "200", "101"))
+      expect(form).to be_invalid
+      expect(form.errors.full_messages).to eq(["点数の合計が 1000 になりません"])
+    end
+  end
+
+  describe "入力不足" do
+    it "3人分しかないと無効（整数エラー扱い）" do
+      three_players_only = scores_for("450", "250", "300").reject { |_, v| v.nil? }
+      form = build_form(three_players_only)
+      expect(form).to be_invalid
+      expect(form.errors.full_messages).to eq(["点数は全プレイヤー分を整数で入力してください"])
+    end
+  end
+
+  describe "検証順序" do
+    it "範囲外と合計不一致が同時に起きたら範囲エラーを優先する" do
+      form = build_form(scores_for("1001", "0", "0", "0"))
+      expect(form).to be_invalid
+      expect(form.errors.full_messages).to eq(["点数は -1000〜1000 の範囲で入力してください"])
+    end
+
+    it "非整数と範囲外が同時に起きたら整数エラーを優先する" do
+      form = build_form(scores_for("abc", "1001", "0", "0"))
+      expect(form).to be_invalid
+      expect(form.errors.full_messages).to eq(["点数は全プレイヤー分を整数で入力してください"])
+    end
+  end
+
+  describe "#units_by_player_id" do
+    it "player_id => 百点棒単位の整数 を返す" do
+      form = build_form(scores_for("450", "250", "200", "100"))
+      expect(form.units_by_player_id).to eq(
+        players[0].id => 450,
+        players[1].id => 250,
+        players[2].id => 200,
+        players[3].id => 100
+      )
+    end
+  end
+end


### PR DESCRIPTION
## 概要

MPA / API の2コントローラーに二重実装されていた点数入力の検証（整数・±1000・合計1000。単位は百点棒＝実点数の1/100）をフォームオブジェクト `RoundScoreForm` に一本化した。振る舞いは変えないリファクタリング。

Closes #193

## 変更内容

- `app/forms/round_score_form.rb` を新設（整数チェック → ±1000 の範囲 → 合計1000 の順で検証）
- `app/controllers/rounds_controller.rb` の重複検証コードを削除し、フォーム呼び出しに置き換え
- `app/controllers/api/v1/rounds_controller.rb` も同様に置き換え
- エラーメッセージは現状維持（MPA は一律「入力内容を確認してください」、API は原因別メッセージ。統一は別イシューで対応）
- `.claude/dependencies.md` にフォームオブジェクトと MPA コントローラーのセクションを追加

## テスト計画

- [x] フォームオブジェクト単体スペックを新設（15件: 正常系・境界値±1000・範囲外±1001・非整数・合計不一致・入力不足・検証順序・`units_by_player_id`）
- [x] 既存のリクエストスペック2本（`spec/requests/rounds_spec.rb` / `spec/requests/api/v1/rounds_spec.rb`）は**変更なしで**グリーン（振る舞い不変の証明）
- [x] 検証ロジックの実装が1箇所だけになっている（両コントローラーから重複コードを削除）
- [x] rspec 全件パス（112件: 既存97 + 新規15）

https://claude.ai/code/session_01VfE987Amv5gxGLZivqpDko