### PR TITLE
メンバー入力画面のルール設定を折りたたみ表示にする（#217）

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -114,6 +114,44 @@
   border-color: #007bff;
 }
 
+/* ルール設定の折りたたみ（#217）。デフォルト値のまま使うことが多いため控えめに表示する */
+.rule-settings {
+  margin-bottom: 2rem;
+}
+
+.rule-settings summary {
+  cursor: pointer;
+  font-weight: bold;
+  color: #666;
+  padding: 0.5rem 0;
+}
+
+.rule-inputs {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.rule-input {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.rule-input label {
+  color: #333;
+}
+
+.rule-input input {
+  width: 8rem;
+  padding: 8px 10px;
+  font-size: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
 .form-actions {
   margin-bottom: 2rem;
 }

--- a/app/views/games/new.html.erb
+++ b/app/views/games/new.html.erb
@@ -11,33 +11,36 @@
       <% end %>
     </div>
 
-    <h2>ルール設定</h2>
-    <div class="rule-inputs">
-      <div class="rule-input">
-        <label for="game_mochi_ten">持ち点</label>
-        <input type="number" name="game[mochi_ten]" id="game_mochi_ten" value="25000">
+    <%# ルール設定はデフォルト値のまま使うことが多いため、初期表示では折りたたむ（#217） %>
+    <details class="rule-settings">
+      <summary>ルール設定</summary>
+      <div class="rule-inputs">
+        <div class="rule-input">
+          <label for="game_mochi_ten">持ち点</label>
+          <input type="number" name="game[mochi_ten]" id="game_mochi_ten" value="25000">
+        </div>
+        <div class="rule-input">
+          <label for="game_kaeshi_ten">返し点</label>
+          <input type="number" name="game[kaeshi_ten]" id="game_kaeshi_ten" value="30000">
+        </div>
+        <div class="rule-input">
+          <label for="game_rank_1_bonus">1位</label>
+          <input type="number" name="game[rank_1_bonus]" id="game_rank_1_bonus" value="50">
+        </div>
+        <div class="rule-input">
+          <label for="game_rank_2_bonus">2位</label>
+          <input type="number" name="game[rank_2_bonus]" id="game_rank_2_bonus" value="10">
+        </div>
+        <div class="rule-input">
+          <label for="game_rank_3_bonus">3位</label>
+          <input type="number" name="game[rank_3_bonus]" id="game_rank_3_bonus" value="-10">
+        </div>
+        <div class="rule-input">
+          <label for="game_rank_4_bonus">4位</label>
+          <input type="number" name="game[rank_4_bonus]" id="game_rank_4_bonus" value="-30">
+        </div>
       </div>
-      <div class="rule-input">
-        <label for="game_kaeshi_ten">返し点</label>
-        <input type="number" name="game[kaeshi_ten]" id="game_kaeshi_ten" value="30000">
-      </div>
-      <div class="rule-input">
-        <label for="game_rank_1_bonus">1位</label>
-        <input type="number" name="game[rank_1_bonus]" id="game_rank_1_bonus" value="50">
-      </div>
-      <div class="rule-input">
-        <label for="game_rank_2_bonus">2位</label>
-        <input type="number" name="game[rank_2_bonus]" id="game_rank_2_bonus" value="10">
-      </div>
-      <div class="rule-input">
-        <label for="game_rank_3_bonus">3位</label>
-        <input type="number" name="game[rank_3_bonus]" id="game_rank_3_bonus" value="-10">
-      </div>
-      <div class="rule-input">
-        <label for="game_rank_4_bonus">4位</label>
-        <input type="number" name="game[rank_4_bonus]" id="game_rank_4_bonus" value="-30">
-      </div>
-    </div>
+    </details>
 
     <div class="form-actions">
       <%= submit_tag "ゲーム開始", class: "btn btn-primary" %>

--- a/e2e/new_game.spec.ts
+++ b/e2e/new_game.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect, Page } from "@playwright/test";
+
+async function fillPlayers(page: Page) {
+  await page.getByLabel("プレイヤー1").fill("Alice");
+  await page.getByLabel("プレイヤー2").fill("Bob");
+  await page.getByLabel("プレイヤー3").fill("Carol");
+  await page.getByLabel("プレイヤー4").fill("Dave");
+}
+
+test.describe("メンバー入力画面", () => {
+  test("初期表示ではルール設定が折りたたまれている", async ({ page }) => {
+    await page.goto("/games/new");
+
+    await expect(page.getByText("ルール設定")).toBeVisible();
+    await expect(page.getByLabel("持ち点")).toBeHidden();
+  });
+
+  test("トグルをタップするとルール設定が開く", async ({ page }) => {
+    await page.goto("/games/new");
+
+    await page.getByText("ルール設定").click();
+
+    await expect(page.getByLabel("持ち点")).toBeVisible();
+    await expect(page.getByLabel("持ち点")).toHaveValue("25000");
+  });
+
+  test("折りたたんだまま（デフォルト値のまま）ゲーム開始できる", async ({ page }) => {
+    await page.goto("/games/new");
+    await fillPlayers(page);
+
+    await page.getByRole("button", { name: "ゲーム開始" }).click();
+
+    // スコア一覧（1回戦目の入力リンクが表示される）に遷移する
+    await expect(page.getByRole("link", { name: "1", exact: true })).toBeVisible();
+  });
+});

--- a/frontend/app/games/new/page.test.tsx
+++ b/frontend/app/games/new/page.test.tsx
@@ -58,6 +58,48 @@ describe("NewGamePage (ゲーム作成フォーム)", () => {
     expect(screen.getByLabelText("4位")).toHaveValue(-30);
   });
 
+  it("初期表示ではルール設定が折りたたまれている", () => {
+    render(<NewGamePage />);
+
+    const details = screen.getByText("ルール設定").closest("details");
+    expect(details).not.toHaveAttribute("open");
+  });
+
+  it("トグルをタップするとルール設定が開き、もう一度タップすると閉じる", async () => {
+    render(<NewGamePage />);
+    const user = userEvent.setup();
+    const summary = screen.getByText("ルール設定");
+
+    await user.click(summary);
+    expect(summary.closest("details")).toHaveAttribute("open");
+
+    await user.click(summary);
+    expect(summary.closest("details")).not.toHaveAttribute("open");
+  });
+
+  it("トグルを開いて変更した値で createGame を呼ぶ", async () => {
+    mockedCreateGame.mockResolvedValue(createdGame);
+    render(<NewGamePage />);
+
+    const user = await fillPlayerNames(["東", "南", "西", "北"]);
+    await user.click(screen.getByText("ルール設定"));
+    const mochiTen = screen.getByLabelText("持ち点");
+    await user.clear(mochiTen);
+    await user.type(mochiTen, "30000");
+    await user.click(screen.getByRole("button", { name: "ゲーム開始" }));
+
+    expect(mockedCreateGame).toHaveBeenCalledWith({
+      mochi_ten: 30000,
+      kaeshi_ten: 30000,
+      rank_1_bonus: 50,
+      rank_2_bonus: 10,
+      rank_3_bonus: -10,
+      rank_4_bonus: -30,
+      players: ["東", "南", "西", "北"],
+    });
+  });
+
+  // ルール設定のトグルを開かない（デフォルト値のまま）でも作成できることの確認を兼ねる
   it("入力した値で createGame を呼び、成功したらスコア一覧へ遷移する", async () => {
     mockedCreateGame.mockResolvedValue(createdGame);
     render(<NewGamePage />);

--- a/frontend/app/games/new/page.tsx
+++ b/frontend/app/games/new/page.tsx
@@ -33,6 +33,8 @@ export default function NewGamePage() {
     Array(PLAYER_COUNT).fill("")
   );
   const [rules, setRules] = useState(defaultRules);
+  // ルール設定はデフォルト値のまま使うことが多いため、初期表示では折りたたむ（#217）
+  const [rulesOpen, setRulesOpen] = useState(false);
   const [errors, setErrors] = useState<string[]>([]);
   const [submitting, setSubmitting] = useState(false);
 
@@ -98,20 +100,30 @@ export default function NewGamePage() {
           ))}
         </div>
 
-        <h2>ルール設定</h2>
-        <div className="rule-inputs">
-          {ruleFields.map(({ key, label }) => (
-            <div key={key} className="rule-input">
-              <label htmlFor={`rule_${key}`}>{label}</label>
-              <input
-                type="number"
-                id={`rule_${key}`}
-                value={rules[key]}
-                onChange={(event) => updateRule(key, event.target.value)}
-              />
-            </div>
-          ))}
-        </div>
+        {/* MPA 版（details/summary）と見た目を揃えるため、同じマークアップを state で制御する */}
+        <details className="rule-settings" open={rulesOpen}>
+          <summary
+            onClick={(event) => {
+              event.preventDefault();
+              setRulesOpen((current) => !current);
+            }}
+          >
+            ルール設定
+          </summary>
+          <div className="rule-inputs">
+            {ruleFields.map(({ key, label }) => (
+              <div key={key} className="rule-input">
+                <label htmlFor={`rule_${key}`}>{label}</label>
+                <input
+                  type="number"
+                  id={`rule_${key}`}
+                  value={rules[key]}
+                  onChange={(event) => updateRule(key, event.target.value)}
+                />
+              </div>
+            ))}
+          </div>
+        </details>
 
         <div className="form-actions">
           <button type="submit" className="btn btn-primary" disabled={submitting}>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -127,6 +127,44 @@ body {
   border-color: #007bff;
 }
 
+/* ルール設定の折りたたみ（#217）。デフォルト値のまま使うことが多いため控えめに表示する */
+.rule-settings {
+  margin-bottom: 2rem;
+}
+
+.rule-settings summary {
+  cursor: pointer;
+  font-weight: bold;
+  color: #666;
+  padding: 0.5rem 0;
+}
+
+.rule-inputs {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.rule-input {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.rule-input label {
+  color: #333;
+}
+
+.rule-input input {
+  width: 8rem;
+  padding: 8px 10px;
+  font-size: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
 .form-actions {
   margin-bottom: 2rem;
 }

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe "Games", type: :request do
       expect(response.body).to include('name="game[kaeshi_ten]"')
       expect(response.body).to include('name="game[rank_1_bonus]"')
     end
+
+    it "ルール設定が折りたたみ（details/summary）で表示される" do
+      get new_game_path
+      expect(response.body).to include('<details class="rule-settings">')
+      expect(response.body).to include("<summary>ルール設定</summary>")
+    end
   end
 
   describe "POST /games" do


### PR DESCRIPTION
## Summary
- メンバー入力画面のルール設定（持ち点・返し点・順位点×4）を、初期表示で折りたたむトグル表示に変更（MPA 版・LIFF 版の両方）
- MPA 版は `<details>`/`<summary>`（JavaScript 不要）、LIFF 版は同じ `<details>` マークアップを React の state で制御
- デフォルト値・バリデーション・送信されるパラメータは変更なし（見た目のみの変更）
- 両版共通の `.rule-settings` スタイルを追加し、展開時のルール入力欄の行レイアウトも整理（見た目を揃える方針 #197 に従う）

## Test plan
- [x] RSpec: 113 examples, 0 failures（新規: 「ルール設定が折りたたみ（details/summary）で表示される」）
- [x] vitest（frontend）: 40 tests passed（新規: 初期表示で折りたたみ / トグルで開閉 / 開いて変更した値で作成。既存の「デフォルト値のまま作成」テストがトグルを開かずに通ることで、折りたたんだままの作成も確認）
- [x] E2E（Playwright）: 11 passed（新規 `e2e/new_game.spec.ts`: 初期表示で折りたたみ / トグルで開く / 折りたたんだままゲーム開始→スコア一覧）
- [x] ローカルで目視確認（MPA: localhost:3000 / LIFF: localhost:3001、開閉トグルと送信動作を確認）

## Fixes
- Fixes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CfpG5EmDVTPvaZVWXphXpC