### PR TITLE
chore: APP_VERSION を 0.2.1 に更新（v0.2.1 リリース準備）

### DIFF
--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -1,1 +1,1 @@
-APP_VERSION = "0.2.0"
+APP_VERSION = "0.2.1"


### PR DESCRIPTION
## Summary
- 本番リリース v0.2.1 に向けて `APP_VERSION` を `0.2.0` → `0.2.1` に更新する
- 本番デプロイの前にバージョンを上げることで、本番に載るコードと表示バージョンを一致させる

## v0.2.0 以降の本番反映分

| 変更 | 種別 | 本番影響 |
|---|---|---|
| #193 点数バリデーションを `RoundScoreForm` に一本化 | リファクタ | あり（Rails コントローラー・モデル） |
| #217 メンバー入力画面のルール設定を折りたたみ表示に | UI改善 | あり（MPA ビュー・LIFF `games/new`・CSS） |
| #227 セッション開始フックで Docker デーモンを自動起動 | 開発ツール | なし |
| #238 デバッグ初動用のログ参照ガイドを追加 | ドキュメント | なし |
| #206 README に LINE 友だち追加 QR コードを追加 | ドキュメント | なし |

新機能の追加はなく、UI 改善と内部整理のため **patch バージョン**とした。

## DB への影響

**なし。** v0.2.0 以降に新規マイグレーションはない（`git diff --name-only v0.2.0..main -- db/migrate/` が空であることを確認済み）。データ移行・ロールバックの考慮は不要。

## Test plan
- [x] `APP_VERSION` が `0.2.1` になっている
- [x] RSpec 全 97 件パス（push 前フックで実行）
- [x] CI（test / e2e）がグリーン
- [ ] マージ後、EC2 へデプロイして本番で表示バージョンが `0.2.1` になることを確認する

## リリース手順における位置づけ

1. **このPRをマージ** ← いまここ
2. EC2 へデプロイ（Rails: `assets:precompile` + `web` 再起動 / LIFF: 再ビルド + `frontend` 再起動）
3. 本番で動作確認（ルール設定の折りたたみ・ゲーム作成〜スコア一覧・URL共有）
4. `gh release create v0.2.1` でタグを作成

