### PR TITLE
CloudWatch ダッシュボードを追加してインフラの現状を1画面で把握できるようにする

### DIFF
--- a/infra/cloudformation.yml
+++ b/infra/cloudformation.yml
@@ -694,6 +694,15 @@ Resources:
                   "${AlarmDiskHigh.Arn}"
                 ]
               }
+            },
+            {
+              "type": "log", "x": 0, "y": 24, "width": 24, "height": 6,
+              "properties": {
+                "title": "Rails レスポンスタイム（平均・p95、ログから集計）",
+                "region": "${AWS::Region}",
+                "view": "timeSeries", "stacked": false,
+                "query": "SOURCE '/mahjong-score/rails/production' | filter @message like /Completed/ | parse @message /Completed (?<status>\\d{3}) .* in (?<latency>\\d+)ms/ | filter ispresent(latency) | stats avg(latency) as avg_ms, pct(latency, 95) as p95_ms by bin(1h)"
+              }
             }
           ]
         }

--- a/infra/cloudformation.yml
+++ b/infra/cloudformation.yml
@@ -558,6 +558,146 @@ Resources:
       OKActions:
         - !Ref SNSAlarmTopic
 
+  # ----------------------------------------------------------
+  # 11. CloudWatch Dashboard — インフラの現状を1画面で把握（#253）
+  # ----------------------------------------------------------
+  # ディスク使用率の推移は #215（EBS拡張の見極め）の判断材料。
+  # ダッシュボードは3個・50メトリクスまで無料枠内（本ダッシュボードは約12メトリクス）。
+  MonitoringDashboard:
+    Type: AWS::CloudWatch::Dashboard
+    Properties:
+      DashboardName: mahjong-score
+      DashboardBody: !Sub |
+        {
+          "widgets": [
+            {
+              "type": "metric", "x": 0, "y": 0, "width": 12, "height": 6,
+              "properties": {
+                "title": "ディスク使用率 / （#215 EBS拡張の判断材料）",
+                "region": "${AWS::Region}", "view": "timeSeries", "stat": "Average", "period": 300,
+                "metrics": [
+                  ["CWAgent", "disk_used_percent", "path", "/", "InstanceId", "${EC2Instance}", "device", "xvda1", "fstype", "xfs", {"label": "ディスク使用率(%)"}]
+                ],
+                "yAxis": {"left": {"min": 0, "max": 100}},
+                "annotations": {"horizontal": [{"label": "アラーム閾値 80%", "value": 80}]}
+              }
+            },
+            {
+              "type": "metric", "x": 12, "y": 0, "width": 12, "height": 6,
+              "properties": {
+                "title": "メモリ使用率",
+                "region": "${AWS::Region}", "view": "timeSeries", "stat": "Average", "period": 300,
+                "metrics": [
+                  ["CWAgent", "mem_used_percent", "InstanceId", "${EC2Instance}", {"label": "メモリ使用率(%)"}]
+                ],
+                "yAxis": {"left": {"min": 0, "max": 100}},
+                "annotations": {"horizontal": [{"label": "アラーム閾値 80%", "value": 80}]}
+              }
+            },
+            {
+              "type": "metric", "x": 0, "y": 6, "width": 8, "height": 6,
+              "properties": {
+                "title": "EC2 CPU使用率",
+                "region": "${AWS::Region}", "view": "timeSeries", "stat": "Average", "period": 300,
+                "metrics": [
+                  ["AWS/EC2", "CPUUtilization", "InstanceId", "${EC2Instance}", {"label": "CPU使用率(%)"}]
+                ],
+                "yAxis": {"left": {"min": 0, "max": 100}},
+                "annotations": {"horizontal": [{"label": "アラーム閾値 80%", "value": 80}]}
+              }
+            },
+            {
+              "type": "metric", "x": 8, "y": 6, "width": 8, "height": 6,
+              "properties": {
+                "title": "EC2 CPUクレジット残高（バースト枯渇の検知）",
+                "region": "${AWS::Region}", "view": "timeSeries", "stat": "Average", "period": 300,
+                "metrics": [
+                  ["AWS/EC2", "CPUCreditBalance", "InstanceId", "${EC2Instance}", {"label": "クレジット残高"}]
+                ],
+                "yAxis": {"left": {"min": 0}}
+              }
+            },
+            {
+              "type": "metric", "x": 16, "y": 6, "width": 8, "height": 6,
+              "properties": {
+                "title": "EC2 ネットワーク In/Out",
+                "region": "${AWS::Region}", "view": "timeSeries", "stat": "Sum", "period": 300,
+                "metrics": [
+                  ["AWS/EC2", "NetworkIn", "InstanceId", "${EC2Instance}", {"label": "受信(バイト)"}],
+                  ["AWS/EC2", "NetworkOut", "InstanceId", "${EC2Instance}", {"label": "送信(バイト)"}]
+                ],
+                "yAxis": {"left": {"min": 0}}
+              }
+            },
+            {
+              "type": "metric", "x": 0, "y": 12, "width": 8, "height": 6,
+              "properties": {
+                "title": "RDS CPU使用率",
+                "region": "${AWS::Region}", "view": "timeSeries", "stat": "Average", "period": 300,
+                "metrics": [
+                  ["AWS/RDS", "CPUUtilization", "DBInstanceIdentifier", "${RDSInstance}", {"label": "CPU使用率(%)"}]
+                ],
+                "yAxis": {"left": {"min": 0, "max": 100}}
+              }
+            },
+            {
+              "type": "metric", "x": 8, "y": 12, "width": 8, "height": 6,
+              "properties": {
+                "title": "RDS 空きストレージ",
+                "region": "${AWS::Region}", "view": "timeSeries", "stat": "Average", "period": 300,
+                "metrics": [
+                  ["AWS/RDS", "FreeStorageSpace", "DBInstanceIdentifier", "${RDSInstance}", {"label": "空きストレージ(バイト)"}]
+                ],
+                "yAxis": {"left": {"min": 0}}
+              }
+            },
+            {
+              "type": "metric", "x": 16, "y": 12, "width": 8, "height": 6,
+              "properties": {
+                "title": "RDS 空きメモリ",
+                "region": "${AWS::Region}", "view": "timeSeries", "stat": "Average", "period": 300,
+                "metrics": [
+                  ["AWS/RDS", "FreeableMemory", "DBInstanceIdentifier", "${RDSInstance}", {"label": "空きメモリ(バイト)"}]
+                ],
+                "yAxis": {"left": {"min": 0}}
+              }
+            },
+            {
+              "type": "metric", "x": 0, "y": 18, "width": 8, "height": 6,
+              "properties": {
+                "title": "RDS 接続数",
+                "region": "${AWS::Region}", "view": "timeSeries", "stat": "Average", "period": 300,
+                "metrics": [
+                  ["AWS/RDS", "DatabaseConnections", "DBInstanceIdentifier", "${RDSInstance}", {"label": "接続数"}]
+                ],
+                "yAxis": {"left": {"min": 0}}
+              }
+            },
+            {
+              "type": "metric", "x": 8, "y": 18, "width": 8, "height": 6,
+              "properties": {
+                "title": "EC2 ステータスチェック失敗",
+                "region": "${AWS::Region}", "view": "timeSeries", "stat": "Maximum", "period": 300,
+                "metrics": [
+                  ["AWS/EC2", "StatusCheckFailed", "InstanceId", "${EC2Instance}", {"label": "失敗数(0が正常)"}]
+                ],
+                "yAxis": {"left": {"min": 0}}
+              }
+            },
+            {
+              "type": "alarm", "x": 16, "y": 18, "width": 8, "height": 6,
+              "properties": {
+                "title": "アラーム状態（CPU・メモリ・ディスク）",
+                "alarms": [
+                  "${AlarmCPUHigh.Arn}",
+                  "${AlarmMemoryHigh.Arn}",
+                  "${AlarmDiskHigh.Arn}"
+                ]
+              }
+            }
+          ]
+        }
+
 # ==============================================================
 # Outputs: スタック作成後に表示する情報
 # ==============================================================
@@ -585,3 +725,7 @@ Outputs:
   CloudFrontMPAURL:
     Description: "MPA版のHTTPS URL"
     Value: !Sub "https://${CloudFrontMPADistribution.DomainName}"
+
+  DashboardURL:
+    Description: "CloudWatch ダッシュボードのURL"
+    Value: !Sub "https://${AWS::Region}.console.aws.amazon.com/cloudwatch/home?region=${AWS::Region}#dashboards:name=${MonitoringDashboard}"


### PR DESCRIPTION
## 概要
Closes #253

CloudFormation テンプレートに `AWS::CloudWatch::Dashboard` を追加し、EC2・RDS の主要メトリクスを1画面で確認できるようにします。

## 背景
- #215（EBS ボリューム拡張の検討）の判断には、ディスク使用率の増加ペースの可視化が必要
- CloudWatch Agent とアラーム3種は導入済みだが、推移を一目で見る手段がなかった
- #228（本番EC2へのデプロイとイメージミラー化の検証）の最大のリスク要因もディスク容量不足で、既存 `ruby:3.3` の中身次第では約1.6GB のイメージ取得により `no space left on device` の危険がある。本ダッシュボードで**デプロイ前後のディスク使用率の変化を確認**でき、#228 の Test plan「デプロイ後もディスク容量に余裕がある」の裏付けになる

## 変更内容
- `infra/cloudformation.yml` にダッシュボード `mahjong-score`（12ウィジェット・約12メトリクス）を追加
  - 1段目: ディスク使用率（#215 の判断材料の本命）・メモリ使用率（アラーム閾値 80% の注釈線つき）
  - 2段目: EC2 CPU使用率・CPUクレジット残高（t2.micro のバースト枯渇検知）・ネットワーク In/Out
  - 3段目: RDS CPU使用率・空きストレージ・空きメモリ
  - 4段目: RDS 接続数・EC2 ステータスチェック・既存アラーム3種の状態
- **5段目: Rails レスポンスタイム（平均・p95）** — CloudWatch Logs Insights クエリで本番ログの `Completed ... in XXms` から1時間単位で集計（実データで検証済み。直近では平均110ms・p95 1040ms が観測できている）
- Outputs にダッシュボード URL を追加

## レスポンスタイムの計測方式について
- メトリクスフィルターは非構造化ログからの数値抽出に対応していないため、**リソース追加不要の Logs Insights ウィジェット方式**を採用
- 計測されるのはオリジン（Rails）の処理時間。CloudFront 経由の体感時間とは異なる点に注意
- **今回はやらないこと**: CloudFront の OriginLatency 追加メトリクス（約$2.4/月×2ディストリビューションの有料オプション）、CloudWatch Synthetics 外形監視（約$5/月〜）、lograge 等による構造化ログ化。必要になったら別イシューで検討
- Logs Insights はスキャン量課金（約$0.0057/GB）だが、ログ量が小さくダッシュボード閲覧時のみ実行されるためコストは実質ゼロ

## コストと可逆性
- ダッシュボードは3個・50メトリクスまで無料枠内
- **取り返しのつかない要素はなし**（いつでも削除可能な可逆な変更）

## テスト・確認
- [x] `aws cloudformation validate-template` が通ることを確認済み
- [x] DashboardBody の JSON 構文が正しいことを確認済み（12ウィジェット）
- [x] マージ後のスタック更新が UPDATE_COMPLETE になる（2026-08-09 06:44 UTC 実施）
- [x] ダッシュボード `mahjong-score` が作成され、12ウィジェットすべてが定義されていることを確認（ディスク・メモリ・EC2 CPU の実データ取得も確認済み）
- [x] ディスク使用率の現在値が実態と一致する（**#215 の EBS 拡張により前提が変化。91% → 実測 45.54%**。EC2 上の `df` の 46% と一致）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


