### PR TITLE
chore: CloudWatch アラームを拡充する（RDS・ステータスチェック・CPUクレジット）

### DIFF
--- a/infra/cloudformation.yml
+++ b/infra/cloudformation.yml
@@ -558,6 +558,77 @@ Resources:
       OKActions:
         - !Ref SNSAlarmTopic
 
+  # RDS の空きストレージが 2GB を下回ったら発火（#256）
+  # DB が書き込めなくなる前に検知する。割当 20GB に対し 2026-08-09 時点の空きは 18.3GB。
+  # 到達までの余裕が大きく、誤報の心配がない水準として 2GB を採用。
+  AlarmRDSStorageLow:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: mahjong-score-rds-storage-low
+      AlarmDescription: "RDSの空きストレージが2GBを下回った"
+      Namespace: AWS/RDS
+      MetricName: FreeStorageSpace
+      Dimensions:
+        - Name: DBInstanceIdentifier
+          Value: !Ref RDSInstance
+      Statistic: Minimum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 2147483648 # 2GiB
+      ComparisonOperator: LessThanThreshold
+      AlarmActions:
+        - !Ref SNSAlarmTopic
+      OKActions:
+        - !Ref SNSAlarmTopic
+
+  # EC2 のステータスチェック失敗で発火（#256）
+  # インスタンス自体の異常＝アプリ全断に直結するため検知する。
+  # 一時的な揺らぎで鳴らないよう、2回連続（10分）で発火させる。
+  AlarmEC2StatusCheckFailed:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: mahjong-score-ec2-status-check-failed
+      AlarmDescription: "EC2のステータスチェックが2回連続で失敗"
+      Namespace: AWS/EC2
+      MetricName: StatusCheckFailed
+      Dimensions:
+        - Name: InstanceId
+          Value: !Ref EC2Instance
+      Statistic: Maximum
+      Period: 300
+      EvaluationPeriods: 2
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching # インスタンス停止中に発火させない（コスト削減で日常的に停止するため）
+      AlarmActions:
+        - !Ref SNSAlarmTopic
+      OKActions:
+        - !Ref SNSAlarmTopic
+
+  # EC2 の CPUクレジット残高が 50 を下回ったら発火（#256）
+  # t2.micro のバースト枯渇＝性能劣化の前兆。上限144に対し約1/3を閾値とする。
+  # 2026-08-09 時点の残高は 145（ほぼ満タン）で、余裕は十分。
+  AlarmEC2CPUCreditLow:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: mahjong-score-ec2-cpu-credit-low
+      AlarmDescription: "EC2のCPUクレジット残高が50を下回った（バースト枯渇の前兆）"
+      Namespace: AWS/EC2
+      MetricName: CPUCreditBalance
+      Dimensions:
+        - Name: InstanceId
+          Value: !Ref EC2Instance
+      Statistic: Minimum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 50
+      ComparisonOperator: LessThanThreshold
+      TreatMissingData: notBreaching # インスタンス停止中に発火させない
+      AlarmActions:
+        - !Ref SNSAlarmTopic
+      OKActions:
+        - !Ref SNSAlarmTopic
+
   # ----------------------------------------------------------
   # 11. CloudWatch Dashboard — インフラの現状を1画面で把握（#253）
   # ----------------------------------------------------------
@@ -687,11 +758,14 @@ Resources:
             {
               "type": "alarm", "x": 16, "y": 18, "width": 8, "height": 6,
               "properties": {
-                "title": "アラーム状態（CPU・メモリ・ディスク）",
+                "title": "アラーム状態（EC2・RDS）",
                 "alarms": [
                   "${AlarmCPUHigh.Arn}",
                   "${AlarmMemoryHigh.Arn}",
-                  "${AlarmDiskHigh.Arn}"
+                  "${AlarmDiskHigh.Arn}",
+                  "${AlarmRDSStorageLow.Arn}",
+                  "${AlarmEC2StatusCheckFailed.Arn}",
+                  "${AlarmEC2CPUCreditLow.Arn}"
                 ]
               }
             },


### PR DESCRIPTION
## Summary

Closes #256

「気づけないと致命的」な領域に CloudWatch アラームを3件追加する。閾値は**実測値を根拠に保守的に設定**した（誤報が多いと通知が無視されるようになるため）。

## 追加するアラーム

| アラーム | 閾値 | 実測値（2026-08-09） | 根拠 |
|---|---|---|---|
| RDS 空きストレージ低下 | **< 2GiB** | 空き 18.3GB / 割当 20GB | 到達までの余裕が大きく誤報の心配がない。DB が書き込めなくなる前に検知できる |
| EC2 ステータスチェック失敗 | **>= 1 が2回連続**（10分） | 正常 | インスタンス自体の異常＝アプリ全断に直結。1回だと一時的な揺らぎで鳴るため2回連続にした |
| EC2 CPUクレジット残高低下 | **< 50** | 145（上限144でほぼ満タン） | t2.micro のバースト枯渇＝性能劣化の前兆。上限に対し約1/3を閾値とした |

## 実装上の判断

### `TreatMissingData: notBreaching` を EC2 系の2件に指定した

コスト削減のためインスタンスを日常的に停止する運用のため、**停止中にデータ欠損で発火させない**ようにした。指定しないと EC2 を止めるたびにアラームメールが届く。

### RDS 空きメモリは見送った

PostgreSQL はメモリをキャッシュに使い切る性質があり、**「空きが少ない」が常態**（実測 188MB / 1GB）。閾値の決定が難しく誤報を出しやすいため、今回のスコープから外した。必要になったら別イシューで検討する。

### RDS CPU使用率も見送った

現状ほぼ無負荷で、DB のボトルネックが顕在化していないため。ダッシュボード（#253）では可視化済みなので、推移を見て必要になれば追加する。

### ダッシュボードのアラームウィジェットも更新した

`#253` で追加したアラーム状態ウィジェットが既存3件しか表示していなかったため、新規3件を追加してタイトルを「アラーム状態（EC2・RDS）」に変更した。追加したアラームがダッシュボードに映らないと、監視の入口が分散してしまうため。

## コストと可逆性

- アラームは **10件まで無料枠内**。既存3件 + 今回3件 = **合計6件**で範囲内
- 通知先は既存の SNS トピック（`mahjong-score-alarms` → メール通知）をそのまま使う。**新規リソースは作らない**
- **取り返しのつかない要素はなし**（アラームはいつでも削除・閾値変更が可能）
- 既存リソースへの変更はアラームウィジェットの表示のみ。EC2・RDS には影響しない

## Test plan

- [x] `aws cloudformation validate-template` が通る
- [x] マージ後のスタック更新が UPDATE_COMPLETE になる（2026-08-09 07:31 UTC）
- [x] アラーム一覧が3件→6件になり、新規3件が作成されたことを確認
- [x] 新規3件とも INSUFFICIENT_DATA → **OK** に遷移（RDS 16:32:10 / CPUクレジット 16:32:51 / ステータスチェック 16:33:30 JST）
- [x] ダッシュボードのアラームウィジェットに6件すべてが登録されていることを確認（タイトルも「アラーム状態（EC2・RDS）」に更新）
- [x] 既存リソースは無変更。**適用前にチェンジセットで確認**（アラーム3件が Add、ダッシュボードが Modify/Replacement:False、EC2・RDS は変更対象外）。適用後も EC2 インスタンスID `i-061932ee89db4e727`・起動時刻・RDS 作成時刻すべて変化なし

## やらないこと

- 閾値を一時的に厳しくしてメール通知の到達を確認するテスト（イシューの Test plan 最終項目）
  - 実施すると本番のアラームが ALARM 状態になり、通知先にメールが飛ぶ。**必要と判断されたら別途実施する**

## 関連

- #253 CloudWatch ダッシュボードの追加（見る手段。本 PR は通知の拡充）
- #215 EBS 拡張（ディスクアラームは既存。本 PR の対象外）

